### PR TITLE
Add Heart and Swim !

### DIFF
--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -134,7 +134,7 @@ btc_city_type = "Land_Ammobox_rounds_F";
 //Civ
 btc_civ_type_units  = ["C_man_1","C_man_1_1_F","C_man_1_2_F","C_man_1_3_F","C_man_polo_1_F","C_man_polo_2_F","C_man_polo_3_F","C_man_polo_4_F","C_man_polo_5_F","C_man_polo_6_F"];
 btc_civ_type_veh    = ["C_Hatchback_01_F","C_SUV_01_F","C_Offroad_01_F","C_Van_01_transport_F","C_Van_01_box_F"];
-btc_civ_type_boat    = ["C_Rubberboat","C_Boat_Civil_01_F","C_Boat_Civil_01_rescue_F","C_Boat_Civil_01_police_F"];
+btc_civ_type_boats    = ["C_Rubberboat","C_Boat_Civil_01_F","C_Boat_Civil_01_rescue_F","C_Boat_Civil_01_police_F"];
 btc_civ_max_veh = 5;
 btc_w_civs = ["V_Rangemaster_belt","arifle_Mk20_F","30Rnd_556x45_Stanag","hgun_ACPC2_F","9Rnd_45ACP_Mag"];
 

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/civ/traffic_create.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/civ/traffic_create.sqf
@@ -42,7 +42,7 @@ if (count (_pos nearRoads 100) > 0) then {
 
 if (surfaceIsWater _Spos) then {
 	_Spos = [_Spos select 0, _Spos select 1,0];
-	_veh_type = btc_civ_type_boat select (floor (random (count btc_civ_type_boat)));
+	_veh_type = btc_civ_type_boats select (floor (random (count btc_civ_type_boats)));
 	_iswater = true;
 } else {
 	_veh_type = btc_civ_type_veh select (floor (random (count btc_civ_type_veh)));


### PR DESCRIPTION
With Arma 3, BI add a new battlefield in Altis and Stratis, the Sea.
This pull request is proposing to extend the Heart and Mind to this new terrain.

- Add civ boat traffic.
- Add enemy boat patrol.
- Add enemy occupied marine.

The pull request is based on function use to spawn unit and vehicle but now when function select a water area, function choose the appropriate vehicule and unit type and add a WP link to this type. (https://github.com/Giallustio/HeartsAndMinds/issues/65)