### PR TITLE
FIX: btc_patrol_active and btc_civ_veh_active negative

### DIFF
--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -83,7 +83,7 @@ if (isServer) then {
 
 	//Patrol
 	btc_patrol_max = 5;
-	btc_patrol_active = 0;
+	btc_patrol_active = [];
 	btc_patrol_area = 2500;
 
 	//Rep

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -50,7 +50,7 @@ if (isServer) then {
 	btc_city_blacklist = [];//NAME FROM CFG
 
 	//Civ
-	btc_civ_veh_active = 0;
+	btc_civ_veh_active = [];
 
 	//Database
 	btc_db_is_saving = false;

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -1,5 +1,5 @@
 
-private ["_city","_is_init","_data_units","_type","_radius_x","_radius_y","_has_en","_has_ho","_ieds","_radius","_number_patrol_active"];
+private ["_city","_is_init","_data_units","_type","_radius_x","_radius_y","_has_en","_has_ho","_ieds","_radius","_number_patrol_active","_number_civ_veh_active"];
 
 hint ("Activate " + str(_this));
 
@@ -156,11 +156,13 @@ if (_number_patrol_active < btc_patrol_max) then {
 };
 
 //Traffic
-if (btc_civ_veh_active < btc_civ_max_veh) then {
+btc_civ_veh_active = btc_civ_veh_active - [grpNull];
+_number_civ_veh_active = count btc_civ_veh_active;
+if (_number_civ_veh_active < btc_civ_max_veh) then {
 	private ["_n","_av","_d","_r"];
 	_n = 0;_r = 0;
 	_n = round (random 3 + (3/2));
-	_av = btc_civ_max_veh - btc_civ_veh_active;
+	_av = btc_civ_max_veh - _number_civ_veh_active;
 	_d = _n - _av;
 	if (_d > 0) then {_r = _n - _d;} else {_r = _n;};
 	for "_i" from 1 to _r do {

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -1,5 +1,5 @@
 
-private ["_city","_is_init","_data_units","_type","_radius_x","_radius_y","_has_en","_has_ho","_ieds","_radius"];
+private ["_city","_is_init","_data_units","_type","_radius_x","_radius_y","_has_en","_has_ho","_ieds","_radius","_number_patrol_active"];
 
 hint ("Activate " + str(_this));
 
@@ -139,11 +139,13 @@ if (count _ieds > 0) then {
 };
 
 //Patrol
-if (btc_patrol_active < btc_patrol_max) then {
+btc_patrol_active = btc_patrol_active - [grpNull];
+_number_patrol_active = count btc_patrol_active;
+if (_number_patrol_active < btc_patrol_max) then {
 	private ["_n","_av","_d","_r"];
 	_n = 0;_r = 0;
 	if (_has_en) then	{_n = round (random 3 + (3/2));} else {_n = round random 2;};
-	_av = btc_patrol_max - btc_patrol_active;
+	_av = btc_patrol_max - _number_patrol_active;
 	_d = _n - _av;
 	if (_d > 0) then {_r = _n - _d;} else {_r = _n;};
 	for "_i" from 1 to _r do

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/civ/traffic_add_WP.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/civ/traffic_add_WP.sqf
@@ -12,7 +12,6 @@ if ({_x distance _city < (_area/2) || _x distance leader _group < (_area/2)} cou
 	diag_log text "DELETE TRAFFIC GROUP";
 	if (vehicle leader _group != leader _group) then {deleteVehicle (vehicle leader _group)};
 	{deleteVehicle _x;} foreach units _group;deleteGroup _group;
-	btc_civ_veh_active = btc_civ_veh_active - 1;
 };
 
 _cities = [];

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/civ/traffic_create.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/civ/traffic_create.sqf
@@ -4,7 +4,6 @@ private ["_city","_area","_cities","_useful","_unit_type","_veh_type","_group","
 _city = _this select 0;
 _area = _this select 1;
 
-btc_civ_veh_active = btc_civ_veh_active + 1;
 if (isNil "btc_traffic_id") then {btc_traffic_id = 0;};
 
 _cities = [];
@@ -60,6 +59,8 @@ _3 = _veh addEventHandler ["GetOut", {_this call btc_fnc_civ_traffic_eh}];
 
 _veh setVariable ["eh", [_1,_2,_3/*,4,5*/]];
 _veh setVariable ["driver", leader _group];
+
+btc_civ_veh_active pushBack _group;
 
 {_x call btc_fnc_civ_unit_create;_x setVariable ["traffic",_veh];} foreach units _group;
 

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/civ/traffic_eh.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/civ/traffic_eh.sqf
@@ -11,6 +11,4 @@ _veh call btc_fnc_civ_traffic_eh_remove;
 [_veh,(_veh getVariable ["driver",_veh])] spawn {
 	waitUntil {sleep 5; ({_x distance (_this select 0) < 600} count playableUnits == 0)};
 	{deleteVehicle _x;} foreach _this;
-	if (isNull (_this select 0)) exitWith {};//Just to be sure
-	btc_civ_veh_active = btc_civ_veh_active - 1;
 };

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/patrol_addWP.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/patrol_addWP.sqf
@@ -11,7 +11,6 @@ _players = if (isMultiplayer) then {playableUnits} else {switchableUnits};
 if ({_x distance _city < (_area/2) || _x distance leader _group < (_area/2)} count _players == 0) exitWith {
 	if (vehicle leader _group != leader _group) then {deleteVehicle (vehicle leader _group)};
 	{deleteVehicle _x;} foreach units _group;deleteGroup _group;
-	btc_patrol_active = btc_patrol_active - 1;
 };
 
 _cities = [];

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/patrol_create.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/patrol_create.sqf
@@ -59,7 +59,6 @@ switch (true) do {
 			sleep 0.1;
 		};
 		_spawn = [_group,_area,_iswater] spawn btc_fnc_mil_patrol_addWP;
-		{_x call btc_fnc_mil_unit_create} foreach units _group;
 	};
 	case ((_random == 2) || _iswater) : {
 		private ["_veh_type","_newZone","_veh","_cargo"];
@@ -88,13 +87,7 @@ switch (true) do {
 			};
 		};
 		_spawn = [_group,_area,_iswater] spawn btc_fnc_mil_patrol_addWP;
-
-		(leader _group) addEventHandler ["Killed",{_this call btc_fnc_mil_unit_killed}];
-		_veh addEventHandler ["GetOut",{(_this select 2) addEventHandler ["Killed",{_this call btc_fnc_mil_unit_killed}];}];
-		{
-			if (_x getVariable ["btc_init", false]) exitWith {true};
-			_x setVariable ["btc_init",true];
-			if (btc_p_set_skill) then {_x call btc_fnc_mil_set_skill;};
-		} forEach units _group;
 	};
 };
+
+{_x call btc_fnc_mil_unit_create} foreach units _group;

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/patrol_create.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/patrol_create.sqf
@@ -7,9 +7,7 @@ _area = _this select 2;
 
 if (isNil "btc_patrol_id") then {btc_patrol_id = 0;};
 
-btc_patrol_active = btc_patrol_active + 1;
-
-if (btc_debug_log) then {diag_log format ["btc_fnc_mil_patrol_create: _random = %1 _city %2 _area %3 btc_patrol_active = %4",_random,_city,_area,btc_patrol_active];};
+if (btc_debug_log) then {diag_log format ["btc_fnc_mil_patrol_create: _random = %1 _city %2 _area %3 btc_patrol_active = %4",_random,_city,_area,count(btc_patrol_active)];};
 
 if (_random == 0) then {
 	private ["_n"];
@@ -89,5 +87,7 @@ switch (true) do {
 		_spawn = [_group,_area,_iswater] spawn btc_fnc_mil_patrol_addWP;
 	};
 };
+
+btc_patrol_active pushBack _group;
 
 {_x call btc_fnc_mil_unit_create} foreach units _group;

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/patrol_create.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/patrol_create.sqf
@@ -59,6 +59,7 @@ switch (true) do {
 			sleep 0.1;
 		};
 		_spawn = [_group,_area,_iswater] spawn btc_fnc_mil_patrol_addWP;
+		{_x call btc_fnc_mil_unit_create} foreach units _group;
 	};
 	case ((_random == 2) || _iswater) : {
 		private ["_veh_type","_newZone","_veh","_cargo"];
@@ -87,7 +88,13 @@ switch (true) do {
 			};
 		};
 		_spawn = [_group,_area,_iswater] spawn btc_fnc_mil_patrol_addWP;
+
+		(leader _group) addEventHandler ["Killed",{_this call btc_fnc_mil_unit_killed}];
+		_veh addEventHandler ["GetOut",{(_this select 2) addEventHandler ["Killed",{_this call btc_fnc_mil_unit_killed}];}];
+		{
+			if (_x getVariable ["btc_init", false]) exitWith {true};
+			_x setVariable ["btc_init",true];
+			if (btc_p_set_skill) then {_x call btc_fnc_mil_set_skill;};
+		} forEach units _group;
 	};
 };
-
-{_x call btc_fnc_mil_unit_create} foreach units _group;

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_create.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_create.sqf
@@ -15,4 +15,4 @@ if (isNil {_this getVariable "btc_eh_killed_assigned"}) then
 	_this setVariable ["btc_eh_killed_assigned",true];
 };
 */
-true
+true 

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_create.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_create.sqf
@@ -4,7 +4,11 @@ if (_this getVariable ["btc_init", false]) exitWith {true};
 
 _this setVariable ["btc_init",true];
 
-_this addEventHandler ["Killed",{_this call btc_fnc_mil_unit_killed}];
+if ((vehicle _this != _this) && (leader group _this != _this)) then {
+	(vehicle _this) addEventHandler ["GetOut",{(_this select 2) addEventHandler ["Killed",{_this call btc_fnc_mil_unit_killed}];}];
+} else {
+	_this addEventHandler ["Killed",{_this call btc_fnc_mil_unit_killed}];
+};
 
 if (btc_p_set_skill) then {_this call btc_fnc_mil_set_skill;};
 
@@ -15,4 +19,4 @@ if (isNil {_this getVariable "btc_eh_killed_assigned"}) then
 	_this setVariable ["btc_eh_killed_assigned",true];
 };
 */
-true 
+true

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_create.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_create.sqf
@@ -4,11 +4,7 @@ if (_this getVariable ["btc_init", false]) exitWith {true};
 
 _this setVariable ["btc_init",true];
 
-if ((vehicle _this != _this) && (leader group _this != _this)) then {
-	(vehicle _this) addEventHandler ["GetOut",{(_this select 2) addEventHandler ["Killed",{_this call btc_fnc_mil_unit_killed}];}];
-} else {
-	_this addEventHandler ["Killed",{_this call btc_fnc_mil_unit_killed}];
-};
+_this addEventHandler ["Killed",{_this call btc_fnc_mil_unit_killed}];
 
 if (btc_p_set_skill) then {_this call btc_fnc_mil_set_skill;};
 

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_killed.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_killed.sqf
@@ -6,8 +6,4 @@ if (isPlayer (_this select 1)) then {
 	if (isServer) then {btc_rep_bonus_mil_killed call btc_fnc_rep_change;} else {[btc_rep_bonus_mil_killed,"btc_fnc_rep_change",false] spawn BIS_fnc_MP;};
 };
 
-if ((group (_this select 0)) getVariable ["btc_patrol",false] && {({Alive _x} count units (group (_this select 0)) == 0)}) then {
-	btc_patrol_active = btc_patrol_active - 1;
-};
-
 //(_this select 0) spawn {sleep 0.5;{deleteVehicle _x} foreach (nearestObjects [_this, ["WeaponHolderSimulated"], 5]);};

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_killed.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_killed.sqf
@@ -8,6 +8,7 @@ if (isPlayer (_this select 1)) then {
 
 if ((group (_this select 0)) getVariable ["btc_patrol",false] && {({Alive _x} count units (group (_this select 0)) == 0)}) then {
 	btc_patrol_active = btc_patrol_active - 1;
+	if (btc_patrol_active < 0) then {btc_patrol_active = 0;};
 };
 
 //(_this select 0) spawn {sleep 0.5;{deleteVehicle _x} foreach (nearestObjects [_this, ["WeaponHolderSimulated"], 5]);};

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_killed.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/mil/unit_killed.sqf
@@ -8,7 +8,6 @@ if (isPlayer (_this select 1)) then {
 
 if ((group (_this select 0)) getVariable ["btc_patrol",false] && {({Alive _x} count units (group (_this select 0)) == 0)}) then {
 	btc_patrol_active = btc_patrol_active - 1;
-	if (btc_patrol_active < 0) then {btc_patrol_active = 0;};
 };
 
 //(_this select 0) spawn {sleep 0.5;{deleteVehicle _x} foreach (nearestObjects [_this, ["WeaponHolderSimulated"], 5]);};

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/rep/killed.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/rep/killed.sqf
@@ -13,6 +13,5 @@ if !(isNil {_unit getVariable ["traffic",objNull]}) then {
 	[getPos _unit,(_unit getVariable ["traffic",objNull])] spawn {
 		waitUntil {sleep 5; ({_x distance (_this select 0) < 300} count playableUnits == 0)};
 		deleteVehicle (_this select 1);
-		btc_civ_veh_active = btc_civ_veh_active - 1;
 	};
 };


### PR DESCRIPTION
https://github.com/Giallustio/HeartsAndMinds/issues/81

Now btc_patrol_active or btc_civ_veh_active is an array of group. If all unit is dead in a group, group is grpNull.
If the array has grpNull element,  grpNull is remove from the array (https://github.com/Vdauphin/HeartsAndMinds/pull/80/files#diff-815b391aa171bb9c7461b29c0bee0a78R142) (https://github.com/Vdauphin/HeartsAndMinds/pull/80/files#diff-815b391aa171bb9c7461b29c0bee0a78R159)
After, the number of element in array is checked with btc_patrol_max (https://github.com/Vdauphin/HeartsAndMinds/pull/80/files#diff-815b391aa171bb9c7461b29c0bee0a78R159).