### PR TITLE
Optimize saving big array (more than 8k)

### DIFF
--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -45,6 +45,8 @@ if (isServer) then {
 	btc_fnc_db_save = compile preprocessFile "core\fnc\db\save.sqf";
 	btc_fnc_db_delete = compile preprocessFile "core\fnc\db\delete.sqf";
 	btc_fnc_db_save_array = compile preprocessFile "core\fnc\db\save_array.sqf";
+	btc_fnc_db_array_to_string = compile preprocessFile "core\fnc\db\array_to_string.sqf";
+	btc_fnc_db_string_to_array = compile preprocessFile "core\fnc\db\string_to_array.sqf";
 
 	//EH
 	//btc_fnc_eh_helo_respawn = compile preprocessFile "core\fnc\eh\helo_respawn.sqf";

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/array_to_string.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/array_to_string.sqf
@@ -1,0 +1,17 @@
+#define SIZESTRING 8098
+private ["_array_of_string","_range","_size_array","_string_of_array"];
+
+_string_of_array = str(_this);
+
+_size_array = count _string_of_array;
+_range = floor(_size_array/SIZESTRING);
+_array_of_string = [];
+
+for "_i" from 0 to (_range - 1) do	{
+	_array_of_string pushBack (_string_of_array select [_i * SIZESTRING, SIZESTRING]);
+};
+_array_of_string pushBack (_string_of_array select [_range * SIZESTRING, _size_array]);
+player sideChat "array to string";
+player sideChat str(count _array_of_string);
+player sideChat str(count ((_array_of_string) select 0));
+_array_of_string

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/array_to_string.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/array_to_string.sqf
@@ -2,8 +2,14 @@
 private ["_array_of_string","_range","_size_array","_string_of_array"];
 
 _string_of_array = str(_this);
-
 _size_array = count _string_of_array;
+
+_Doublequotation_pos = _string_of_array find '"';
+while {!(_Doublequotation_pos isEqualTo -1)} do	{
+	_string_of_array = (_string_of_array select [0, _Doublequotation_pos]) + "'" + (_string_of_array select [_Doublequotation_pos + 1, _size_array]);
+	_Doublequotation_pos = _string_of_array find '"';
+};
+
 _range = floor(_size_array/SIZESTRING);
 _array_of_string = [];
 

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -1,17 +1,18 @@
 if !(isClass(configFile >> "cfgPatches" >> "inidbi2")) exitWith {[[11, "loaded"],"btc_fnc_show_hint"] spawn BIS_fnc_MP;};
 
-private ["_cities_status","_fobs","_name","_city_status","_array_ho","_data","_ho_markers","_array_cache","_fobs","_array_veh","_cargo","_array_obj","_marker","_ho","_data_units"];
+private ["_cities_status","_name","_array_ho","_array_cache","_fobs","_marker","_ho","_data_units"];
 
 setDate (["read", ["mission_Param", "date", date]] call OO_fnc_inidbi);
 
 //CITIES
-_nb_cities_status = ((["read", ["cities", "nb_cities_status", [0]]] call OO_fnc_inidbi) select 0) - 1;
+_nb_cities_status = (["read", ["cities", "nb_cities_status", 0]] call OO_fnc_inidbi) - 1;
 _cities_status = [];
 for "_i" from 0 to _nb_cities_status do {
-	_cities_status append (["read", ["cities", format ["cities_status_%1",_i], [] ]] call OO_fnc_inidbi);
+	_cities_status pushBack (["read", ["cities", format ["cities_status_%1",_i], "" ]] call OO_fnc_inidbi);
 };
 
-_nb_cities_data_units = ["read", ["cities", "nb_cities_data_units", [[],[]] ]] call OO_fnc_inidbi;
+_cities_status = _cities_status call btc_fnc_db_string_to_array;
+
 //diag_log format ["_cities_status: %1",_cities_status];
 {
 /*
@@ -38,13 +39,7 @@ _nb_cities_data_units = ["read", ["cities", "nb_cities_data_units", [[],[]] ]] c
 	_city setVariable ["spawn_more",(_x select 2)];
 	_city setVariable ["occupied",(_x select 3)];
 
-	_element = (_nb_cities_data_units select 1) select ((_nb_cities_data_units select 0) find _id);
-	_data_units = [];
-	if (_element > 0) then {
-		for "_i" from 0 to _element do {
-			_data_units append (["read", ["cities", format ["city_%1_data_units_%2",_id,_i], [] ]] call OO_fnc_inidbi);
-		};
-	};
+	_data_units = (_x select 4);
 	{
 		if ((_x select 0) isEqualTo 3) then {
 			_x set [7,([_x select 7,3] call btc_fnc_getHouses) select 0];
@@ -52,9 +47,9 @@ _nb_cities_data_units = ["read", ["cities", "nb_cities_data_units", [[],[]] ]] c
 	} forEach _data_units;
 	_city setVariable ["data_units",_data_units];
 
-	_city setVariable ["has_ho",(_x select 4)];
-	_city setVariable ["ho_units_spawned",(_x select 5)];
-	_city setVariable ["ieds",(_x select 6)];
+	_city setVariable ["has_ho",(_x select 5)];
+	_city setVariable ["ho_units_spawned",(_x select 6)];
+	_city setVariable ["ieds",(_x select 7)];
 
 	if (btc_debug) then	{//_debug
 

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
@@ -124,14 +124,14 @@ _array_veh = [];
 _array_obj = [];
 {
 	if !(!isNil {_x getVariable "loaded"} || !Alive _x || isNull _x) then {
-	_data = [];
-	_data pushBack (typeOf _x);
-	_data pushBack (getPosASL _x);
-	_data pushBack (getDir _x);
-	_cargo = [];
-	{_cargo pushBack (typeOf _x)} foreach (_x getVariable ["cargo",[]]);
-	_data pushBack _cargo;
-	_array_obj pushBack _data;
+		_data = [];
+		_data pushBack (typeOf _x);
+		_data pushBack (getPosASL _x);
+		_data pushBack (getDir _x);
+		_cargo = [];
+		{_cargo pushBack (typeOf _x)} foreach (_x getVariable ["cargo",[]]);
+		_data pushBack _cargo;
+		_array_obj pushBack _data;
 	};
 } foreach btc_log_obj_created;
 ["write", ["base", "objs", _array_obj]] call OO_fnc_inidbi;

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
@@ -2,7 +2,7 @@ if !(isClass(configFile >> "cfgPatches" >> "inidbi2")) exitWith {[[11, "saved"],
 
 "delete" call OO_fnc_inidbi;
 
-private ["_cities_status","_fobs","_name","_city_status","_array_ho","_data","_ho_markers","_array_cache","_fobs","_array_veh","_cargo","_array_obj","_marker","_lereste","_nb_cities_array","_step","_temp_save","_data_units"];
+private ["_cities_status","_fobs","_name","_city_status","_array_ho","_data","_ho_markers","_array_cache","_array_veh","_cargo","_array_obj","_marker","_data_units"];
 
 hint "saving...";
 [[8],"btc_fnc_show_hint"] spawn BIS_fnc_MP;
@@ -20,18 +20,12 @@ hint "saving...2";
 //City status
 hint "saving City status";
 _cities_status = [];
-_nb_cities_data_units = [[],[]];
 {
 	//[151,false,false,true,false,false,[]]
-	private ["_id"];
 	_city_status = [];
-	_id = (_x getVariable "id");
-	_city_status pushBack _id ;
-	(_nb_cities_data_units select 0) pushBack _id;
+	_city_status pushBack (_x getVariable "id");
 	//_city_status pushBack (_x getVariable "name");
-
 	_city_status pushBack (_x getVariable "initialized");
-
 	_city_status pushBack (_x getVariable "spawn_more");
 	_city_status pushBack (_x getVariable "occupied");
 
@@ -41,7 +35,7 @@ _nb_cities_data_units = [[],[]];
 			_x set [7,getPos (_x select 7)];
 		};
 	} forEach _data_units;
-	(_nb_cities_data_units select 1) pushBack ([_data_units,"cities",format ["city_%1_data_units",(_city_status select 0)]] call btc_fnc_db_save_array);
+	_city_status pushBack _data_units;
 
 	_city_status pushBack (_x getVariable ["has_ho",false]);
 	_city_status pushBack (_x getVariable ["ho_units_spawned",false]);
@@ -50,14 +44,10 @@ _nb_cities_data_units = [[],[]];
 	_cities_status pushBack _city_status;
 	//diag_log format ["SAVE: %1 - %2",(_x getVariable "id"),(_x getVariable "occupied")];
 } foreach btc_city_all;
-["write", ["cities", "nb_cities_data_units", _nb_cities_data_units]] call OO_fnc_inidbi;
-
-_nb_cities_status = [[_cities_status,"cities","cities_status"] call btc_fnc_db_save_array];
-["write", ["cities", "nb_cities_status", _nb_cities_status]] call OO_fnc_inidbi;
-
+["write", ["cities", "nb_cities_status", [_cities_status,"cities","cities_status"] call btc_fnc_db_save_array]] call OO_fnc_inidbi;
 
 //HIDEOUT
-hint "saving HIDEOUT";
+//hint "saving HIDEOUT";
 _array_ho = [];
 {
 	_data = [];
@@ -82,7 +72,7 @@ _array_ho = [];
 ["write", ["cities", "ho_sel", (btc_hq getVariable ["info_hideout",objNull]) getVariable ["id",0] ]] call OO_fnc_inidbi;
 
 //CACHE
-hint "saving CACHE";
+//hint "saving CACHE";
 _array_cache = [];
 _array_cache pushback (getposATL btc_cache_obj);
 _array_cache pushback (btc_cache_n);
@@ -147,7 +137,7 @@ _array_obj = [];
 ["write", ["base", "objs", _array_obj]] call OO_fnc_inidbi;
 
 //
-hint "saving...3";
-[[9],"btc_fnc_show_hint"] spawn BIS_fnc_MP;
+//hint "saving...3";
+//[[9],"btc_fnc_show_hint"] spawn BIS_fnc_MP;
 
 btc_db_is_saving = false;

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/save_array.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/save_array.sqf
@@ -1,37 +1,11 @@
 
-private ["_array_to_save","_section","_key","_number_of_array","_step","_temp_save","_size_temp_array"];
+private ["_array_of_string","_section","_key"];
 
-_array_to_save = _this select 0;
+_array_of_string = (_this select 0) call btc_fnc_db_array_to_string;
 _section = _this select 1;
 _key = _this select 2;
 
-_step = count _array_to_save;
-_number_of_array = 0;
-
-while {!(_array_to_save isEqualTo [])} do	{
-	if (_step isEqualTo 0) exitWith {
-		hint "Error Array too big";
-		_nb_cities_array ="Error Array too big";
-	};
-
-	_temp_save = +_array_to_save;
-	_temp_save resize _step;
-	_size_temp_array = count (str(_temp_save));
-	switch (_size_temp_array < 8100) do	{
-		case true:
-		{
-			["write", [_section, format ["%1_%2",_key,_number_of_array], _temp_save]] call OO_fnc_inidbi;
-			_array_to_save deleteRange [0,_step];
-			if (count _array_to_save < _step) then {_step = count _array_to_save};
-			_number_of_array = _number_of_array + 1;
-		};
-		default
-		{
-			player sideChat str(_size_temp_array/8100);
-			player sideChat str(_step);
-			_step = floor(_step/ (_size_temp_array/8100));
-			player sideChat str(_step);
-		};
-	};
-};
-_number_of_array
+{
+	["write", [_section, format ["%1_%2",_key,_forEachIndex], _x]] call OO_fnc_inidbi;
+} forEach _array_of_string;
+count _array_of_string

--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/string_to_array.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/db/string_to_array.sqf
@@ -1,0 +1,9 @@
+
+private ["_string_of_array"];
+
+_string_of_array = "";
+{
+	_string_of_array = _string_of_array + _x;
+} forEach _this;
+
+call compile _string_of_array


### PR DESCRIPTION
The idea here is to create a string of array : "[city1,city2,city3]" . Next I divide this string in string of 8100 size and store each 8100 string in keys ("cities1","cities2","cities3") . Result : 
 - cities1=""[city1"" 
 - cities2="",cit""
 - cities3 = ""y2,city3] ""
 The load phase is done by reading ("cities1","cities2","cities3")  and do `cities1 + cities2 + cities3 `.