### PR TITLE
FIX: hideout marker after server restart

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -79,7 +79,7 @@ _array_ho = profileNamespace getVariable [format ["btc_hm_%1_ho",_name],[]];
 	_hideout setVariable ["id",(_x select 1)];
 	_hideout setVariable ["rinf_time",(_x select 2)];
 	_hideout setVariable ["cap_time",(_x select 3)];
-	_hideout setVariable ["assigned_to",(_x select 4)];
+	_hideout setVariable ["assigned_to", btc_city_all select (_x select 4)];
 
 	_hideout addEventHandler ["HandleDamage", btc_fnc_mil_hd_hideout];
 
@@ -110,8 +110,8 @@ _array_ho = profileNamespace getVariable [format ["btc_hm_%1_ho",_name],[]];
 	btc_hideouts = btc_hideouts + [_hideout];
 } foreach _array_ho;
 
-_ho = profileNamespace getVariable [format ["btc_hm_%1_ho_sel",_name],objNull];
-btc_hq setVariable ["info_hideout",_ho];
+_ho = profileNamespace getVariable [format ["btc_hm_%1_ho_sel",_name],0];
+btc_hq setVariable ["info_hideout", btc_hideouts select _ho];
 
 if (count btc_hideouts == 0) then {[] execVM "core\fnc\common\final_phase.sqf";};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
@@ -60,7 +60,7 @@ _array_ho = [];
 	_data pushBack (_x getVariable ["id",0]);
 	_data pushBack (_x getVariable ["rinf_time",0]);
 	_data pushBack (_x getVariable ["cap_time",0]);
-	_data pushBack (_x getVariable ["assigned_to",objNull]);
+	_data pushBack ((_x getVariable ["assigned_to",objNull]) getVariable "id");
 
 	private ["_ho_markers"];
 	_ho_markers = [];
@@ -77,7 +77,7 @@ _array_ho = [];
 } foreach btc_hideouts;
 profileNamespace setVariable [format ["btc_hm_%1_ho",_name],_array_ho];
 
-profileNamespace setVariable [format ["btc_hm_%1_ho_sel",_name],(btc_hq getVariable ["info_hideout",objNull])];
+profileNamespace setVariable [format ["btc_hm_%1_ho_sel",_name],(btc_hq getVariable ["info_hideout",objNull]) getVariable ["id",0]];
 
 //CACHE
 _array_cache = [];


### PR DESCRIPTION
Object variable are not supported by profileNamespace

Now hideout info are for the same hideout before and after the server restart.

Final test :
- [x] local
- [x] server