### PR TITLE
FIX: traffic wp choose opposite city from spawn

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/traffic_add_WP.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/traffic_add_WP.sqf
@@ -1,5 +1,5 @@
 
-private ["_group","_city","_area","_players","_cities","_pos","_isboat"];
+private ["_group","_city","_area","_players","_cities","_pos","_isboat","_dirTo","_ang","_dirto_useful","_useful"];
 
 _group = _this select 0;
 _city = _group getVariable ["city",objNull];
@@ -14,8 +14,17 @@ if ({_x distance _city < (_area/2) || _x distance leader _group < (_area/2)} cou
 	{deleteVehicle _x;} foreach units _group;deleteGroup _group;
 };
 
-_cities = btc_city_all select {((_x distance _city < _area) && ((!_isboat && {_x getVariable ["type",""] != "NameMarine"}) || (_isboat && {_x getVariable ["hasbeach",false]})))};
-_pos = [];
+_useful =  btc_city_all select {_x distance _city < _area};
+if (btc_debug) then {diag_log text format ["count 1 useful = %1 ",count _useful];};
+_dirTo = (leader _group) getdir _city;
+if (btc_debug) then {diag_log text format ["dirto = %1 ",_dirTo];};
+if (btc_debug) then {diag_log text format ["angle useful = %1 ",_useful apply {_ang = _city getdir _x; (abs(_ang - _dirTo) min (360 - abs(_ang - _dirTo)))}];};
+_dirto_useful = _useful select {_ang = _city getdir _x; (abs(_ang - _dirTo) min (360 - abs(_ang - _dirTo)) < 45);};
+if (btc_debug) then {diag_log text format ["count _dirto_useful = %1 ",count _dirto_useful];};
+if !(_dirto_useful isEqualTo []) then {_useful = _dirto_useful;};
+_cities = _useful select {(!_isboat && {_x getVariable ["type",""] != "NameMarine"}) || (_isboat && {_x getVariable ["hasbeach",false]})};
+if (btc_debug) then {diag_log text format ["count cities = %1 ",count _cities];};
+
 if (_cities isEqualTo []) then {_pos = getPos _city;} else {
 	_pos = getPos (selectRandom _cities);
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/traffic_add_WP.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/traffic_add_WP.sqf
@@ -15,15 +15,10 @@ if ({_x distance _city < (_area/2) || _x distance leader _group < (_area/2)} cou
 };
 
 _useful =  btc_city_all select {_x distance _city < _area};
-if (btc_debug) then {diag_log text format ["count 1 useful = %1 ",count _useful];};
 _dirTo = (leader _group) getdir _city;
-if (btc_debug) then {diag_log text format ["dirto = %1 ",_dirTo];};
-if (btc_debug) then {diag_log text format ["angle useful = %1 ",_useful apply {_ang = _city getdir _x; (abs(_ang - _dirTo) min (360 - abs(_ang - _dirTo)))}];};
 _dirto_useful = _useful select {_ang = _city getdir _x; (abs(_ang - _dirTo) min (360 - abs(_ang - _dirTo)) < 45);};
-if (btc_debug) then {diag_log text format ["count _dirto_useful = %1 ",count _dirto_useful];};
 if !(_dirto_useful isEqualTo []) then {_useful = _dirto_useful;};
 _cities = _useful select {(!_isboat && {_x getVariable ["type",""] != "NameMarine"}) || (_isboat && {_x getVariable ["hasbeach",false]})};
-if (btc_debug) then {diag_log text format ["count cities = %1 ",count _cities];};
 
 if (_cities isEqualTo []) then {_pos = getPos _city;} else {
 	_pos = getPos (selectRandom _cities);

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/traffic_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/traffic_create.sqf
@@ -24,7 +24,7 @@ _unit_type = selectRandom btc_civ_type_units;
 _group = createGroup civilian;
 _group setVariable ["no_cache",true];
 _group setVariable ["btc_patrol",true];
-_group setVariable ["btc_traffic_id",btc_traffic_id];btc_traffic_id = btc_traffic_id + 1;
+_group setVariable ["btc_traffic_id",btc_traffic_id,btc_debug];btc_traffic_id = btc_traffic_id + 1;
 _group setVariable ["city",_city];
 
 _Spos = [];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/patrol_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/patrol_create.sqf
@@ -44,7 +44,7 @@ _group = createGroup btc_enemy_side;
 _group setVariable ["city",_city];
 _group setVariable ["no_cache",true];
 _group setVariable ["btc_patrol",true];
-_group setVariable ["btc_patrol_id",btc_patrol_id];btc_patrol_id = btc_patrol_id + 1;
+_group setVariable ["btc_patrol_id",btc_patrol_id,btc_debug];btc_patrol_id = btc_patrol_id + 1;
 
 _pos_iswater = (surfaceIsWater _pos);
 


### PR DESCRIPTION
FIX: improve civil traffic behavior by choosing appropriate cities 

as before civ traffic spawn randomly around city activated by player.
Now wp for civ car is choose in the opposite of the city car spawn. 

Here is a demonstration :

![107410_20160703193519_1](https://cloud.githubusercontent.com/assets/14364400/16546860/12697816-4159-11e6-83f3-c261b6e1b6b5.png)

if nothing found, normal search is used.

Final test :
- [x] local
- [x] server

