### PR TITLE
FIX: Rearm level selection in mission parameter

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -40,6 +40,7 @@ ace_medical_enableFor = 1;
 btc_p_sea  = if ((paramsArray select 27) isEqualTo 0) then {false} else {true};
 _p_civ = (paramsArray select 28);
 _p_city_radius = (paramsArray select 29) * 100;
+ace_rearm_level = (paramsArray select 30);
 //btc_acre_mod = isClass(configFile >> "cfgPatches" >> "acre_main");
 //btc_tfr_mod = isClass(configFile >> "cfgPatches" >> "task_force_radio");
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -209,4 +209,11 @@ class Params {
 		texts[]={"0 m","100 m","200 m","300 m (Default)","400 m","500 m (Takistan)","600 m","700 m","800 m"};
 		default = 3;
 	};
+	class btc_p_rearm {
+	//paramsArray[30]
+        title = "Rearm Level:";
+		values[]={0,1,2};
+		texts[]={"Entire vehicle","Entire magazine","Amount based on caliber"};
+		default = 1;
+	};
 };


### PR DESCRIPTION
FIX: wrong rearm level at missing starting (now you can select it in mission parameter).

https://github.com/Vdauphin/HeartsAndMinds/issues/163

Final test :
- [x] local
- [x] server