### PR TITLE
FIX: dirt trails are not connected to anything

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/road_direction.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/road_direction.sqf
@@ -3,6 +3,7 @@ private ["_road","_roadConnectedTo","_connectedRoad","_direction"];
 
 _road = _this select 0;
 _roadConnectedTo = roadsConnectedTo _road;
+if (_roadConnectedTo isEqualTo []) exitWith {0};
 _connectedRoad = _roadConnectedTo select 0;
 _direction = _road getDir _connectedRoad;
 


### PR DESCRIPTION
Tanoa map has dirt trails which are not connected to anything and create error
Final test :
- [x] local
- [x] server