### PR TITLE
FIX: EH civilian

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/data/spawn_group.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/data/spawn_group.sqf
@@ -86,3 +86,4 @@ _group setCombatMode (_behaviour select 1);
 _group setFormation (_behaviour select 2);
 
 if (_side == btc_enemy_side) then {{_x call btc_fnc_mil_unit_create} foreach units _group;};
+if (_side == civilian) then {{_x call btc_fnc_civ_unit_create} foreach units _group;};


### PR DESCRIPTION
FIX: player can kill civilian without any reputation effect in some case.

when player comes back in a city, the player can kill or dmage civilian
without reputation effect

Final test :
- [x] local
- [x] server