### PR TITLE
FIX: disable cookoff for side checkpoint

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/checkpoint.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/checkpoint.sqf
@@ -72,6 +72,7 @@ for "_i" from 1 to (1 + round random 2) do {
 	[_pos,_direction,_btc_composition_checkpoint] call btc_fnc_create_composition;
 
 	_boxe = nearestObject [_pos, _type_box];
+	_boxe setVariable ["ace_cookoff_enable", false, true];
 	_boxe spawn {
 		private ["_pos","_fx"];
 		_pos = getpos _this;


### PR DESCRIPTION
FIX: ACE3 cook off animation disable for Side mission checkpoint. 

https://youtu.be/w4lMj7Q3DyE?t=57

Final test :
- [x] local
- [x] server