### PR TITLE
FIX: sometimes objects can't be lift

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_hook.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_hook.sqf
@@ -26,7 +26,10 @@ ropeCreate [vehicle player, "slingload0", _cargo, [((_bbr select 1) select 0), (
 _max_cargo  = getNumber (configFile >> "cfgVehicles" >> typeof _chopper >> "slingLoadMaxCargoMass");
 _mass = getMass _cargo;
 
-waitUntil {local _cargo};
+if !(local _cargo) then {
+	[[_cargo, player],{(_this select 0) setOwner owner (_this select 1);}] remoteExec ["call", 2];
+	waitUntil {local _cargo};
+};
 
 if (_mass > _max_cargo) then {
 	private "_new_mass";


### PR DESCRIPTION
it is an locality issue. now check locality and if not local move object to player ownership and waituntil for it

Final test :
- [x] local
- [x] server