### PR TITLE
FIX: Time acceleration not working when loading

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -9,8 +9,6 @@ if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db",worldNa
 } else {
 	for "_i" from 1 to btc_hideout_n do {[] call btc_fnc_mil_create_hideout;};
 
-	setTimeMultiplier btc_p_acctime;
-
 	[] execVM "core\fnc\cache\init.sqf";
 
 	[] spawn {
@@ -21,6 +19,8 @@ if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db",worldNa
 		} foreach btc_vehicles;
 	};
 };
+
+setTimeMultiplier btc_p_acctime;
 
 call btc_fnc_db_autosave;
 


### PR DESCRIPTION
Time acceleration parameter wouldn't work for us when loading from DB. I didn't find any reference to it being saved, so I imagine it makes sense to move it out of the if and always apply.