### PR TITLE
FIX: Date not being set up properly at the start

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -9,6 +9,10 @@ if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db",worldNa
 } else {
 	for "_i" from 1 to btc_hideout_n do {[] call btc_fnc_mil_create_hideout;};
 
+	private _date = date;
+	_date set [3, btc_p_time];
+	setDate _date;
+
 	[] execVM "core\fnc\cache\init.sqf";
 
 	[] spawn {{waitUntil {!isNull _x};_x addMPEventHandler ["MPKilled", {if (isServer) then {_this call btc_fnc_eh_veh_killed};}];} foreach btc_vehicles;};


### PR DESCRIPTION
FIX: Date not being set up properly at mission start.

Couldn't find any references to setData/skipTime apart from loading, and the date selection never really worked for me (both dedicated & local). Added this to the init server, apparently setDate replicates nicely between clients and server.

Tested on a local server & dedicated, there's a bit of a 2-3s delay on a local server for the date to actually get changed.

Final test :
- [x] local
- [x] server