### PR TITLE
Add: Garage for admin

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -52,6 +52,7 @@ _p_rep = (paramsArray select 35);
 ace_rearm_level = (paramsArray select 36);
 btc_p_sea  = if ((paramsArray select 37) isEqualTo 0) then {false} else {true};
 _p_city_radius = (paramsArray select 38) * 100;
+btc_p_garage = true;
 btc_p_debug  = (paramsArray select 39);
 
 //MED

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -52,7 +52,7 @@ _p_rep = (paramsArray select 35);
 ace_rearm_level = (paramsArray select 36);
 btc_p_sea  = if ((paramsArray select 37) isEqualTo 0) then {false} else {true};
 _p_city_radius = (paramsArray select 38) * 100;
-btc_p_garage = true;
+btc_p_garage = false;
 btc_p_debug  = (paramsArray select 39);
 
 //MED

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -130,7 +130,7 @@ if (isServer) then {
 	//LOG
 	btc_fnc_log_getconfigmagazines = compile preprocessFile "core\fnc\log\getconfigmagazines.sqf";
 	btc_fnc_log_CuratorObjectPlaced_s = compile preprocessFile "core\fnc\log\CuratorObjectPlaced_s.sqf";
-	btc_fnc_log_garage = compile preprocessFile "core\fnc\common\garage.sqf";
+	btc_fnc_log_createVehicle = compile preprocessFile "core\fnc\log\createVehicle.sqf";
 
 	//DEAF
 	btc_fnc_deaf_earringing = compile preprocessFile "core\fnc\deaf\earringing.sqf";
@@ -238,6 +238,9 @@ if (!isDedicated) then {
 	btc_fnc_info_search_for_intel = compile preprocessFile "core\fnc\info\search_for_intel.sqf";
 	btc_fnc_info_troops = compile preprocessFile "core\fnc\info\troops.sqf";
 	btc_fnc_info_ask_reputation = compile preprocessFile "core\fnc\info\ask_reputation.sqf";
+
+	//LOG
+	btc_fnc_log_garage = compile preprocessFile "core\fnc\log\garage.sqf";
 
 	//TASK
 	btc_fnc_task_create = compile preprocessFileLineNumbers "core\fnc\task\create.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -130,6 +130,7 @@ if (isServer) then {
 	//LOG
 	btc_fnc_log_getconfigmagazines = compile preprocessFile "core\fnc\log\getconfigmagazines.sqf";
 	btc_fnc_log_CuratorObjectPlaced_s = compile preprocessFile "core\fnc\log\CuratorObjectPlaced_s.sqf";
+	btc_fnc_log_garage = compile preprocessFile "core\fnc\common\garage.sqf";
 
 	//DEAF
 	btc_fnc_deaf_earringing = compile preprocessFile "core\fnc\deaf\earringing.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -198,14 +198,10 @@ diag_log format ["5: %1",(_x select 5)];
 */
 {
 	private ["_veh","_cont","_weap","_mags","_items"];
-	_veh = (_x select 0) createVehicle (_x select 1);
-	_veh setPosASL (_x select 1);
-	_veh setDir (_x select 2);
+	_veh = [(_x select 0),(_x select 1),(_x select 2)] call btc_fnc_log_createVehicle;
 	if ((getPos _veh) select 2 < 0) then {_veh setVectorUp surfaceNormal position _veh;};
 	_veh setFuel (_x select 3);
 	_veh setDamage (_x select 4);
-	_veh setVariable ["btc_dont_delete",true];
-	_veh call btc_fnc_db_add_veh;
 	{
 		private ["_type","_cargo_obj","_obj","_weap_obj","_mags_obj","_items_obj"];
 		//{_cargo pushBack [(typeOf _x),[getWeaponCargo _x,getMagazineCargo _x,getItemCargo _x]]} foreach (_x getVariable ["cargo",[]]);

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/extended_InitPost_EH.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/extended_InitPost_EH.hpp
@@ -1,12 +1,12 @@
 class Extended_InitPost_EventHandlers {
     class LandVehicle {
         class btc_actions {
-            init = "_this call btc_fnc_eh_veh_init";
+            init = "[typeof (_this select 0)] call btc_fnc_eh_veh_init";
         };
     };
     class Air {
         class btc_actions {
-            init = "_this call btc_fnc_eh_veh_init";
+            init = "[typeof (_this select 0)] call btc_fnc_eh_veh_init";
         };
     };
 	/*class CAManBase {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_init.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_init.sqf
@@ -1,9 +1,5 @@
 
-private ["_veh","_type"];
-
-_veh = _this select 0;
-
-_type = typeOf _veh;
+private _type = _this select 0;
 if (isNil "btc_actions_veh") then {btc_actions_veh = [];};
 if ((btc_actions_veh pushBackUnique _type) isEqualTo -1) exitWith {};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -24,7 +24,7 @@ _action = ["Require_object", "Require object", "\A3\ui_f\data\igui\cfg\simpleTas
 [btc_create_object, 0, ["ACE_MainActions","Logistic"], _action] call ace_interact_menu_fnc_addActionToObject;
 _action = ["Repair_wreck", "Repair wreck", "\A3\ui_f\data\igui\cfg\simpleTasks\types\repair_ca.paa", {[btc_create_object_point] spawn btc_fnc_log_repair_wreck}, {true}, {}, [], [0,0,0], 5] call ace_interact_menu_fnc_createAction;
 [btc_create_object, 0, ["ACE_MainActions","Logistic"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["Require_veh", "Require veh", "\A3\ui_f\data\igui\cfg\simpleTasks\types\repair_ca.paa", {[btc_create_object_point] spawn btc_fnc_log_garage}, {(serverCommandAvailable "#logout" || isMultiplayer) and btc_p_garage}, {}, [], [0,0,0], 5] call ace_interact_menu_fnc_createAction;
+_action = ["Require_veh", "Require vehicle", "\A3\ui_f\data\map\vehicleicons\iconCar_ca.paa", {[btc_create_object_point] spawn btc_fnc_log_garage}, {(serverCommandAvailable "#logout" || !isMultiplayer) and btc_p_garage}, {}, [], [0,0,0], 5] call ace_interact_menu_fnc_createAction;
 [btc_create_object, 0, ["ACE_MainActions","Logistic"], _action] call ace_interact_menu_fnc_addActionToObject;
 
 //Logistic

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -24,6 +24,8 @@ _action = ["Require_object", "Require object", "\A3\ui_f\data\igui\cfg\simpleTas
 [btc_create_object, 0, ["ACE_MainActions","Logistic"], _action] call ace_interact_menu_fnc_addActionToObject;
 _action = ["Repair_wreck", "Repair wreck", "\A3\ui_f\data\igui\cfg\simpleTasks\types\repair_ca.paa", {[btc_create_object_point] spawn btc_fnc_log_repair_wreck}, {true}, {}, [], [0,0,0], 5] call ace_interact_menu_fnc_createAction;
 [btc_create_object, 0, ["ACE_MainActions","Logistic"], _action] call ace_interact_menu_fnc_addActionToObject;
+_action = ["Require_veh", "Require veh", "\A3\ui_f\data\igui\cfg\simpleTasks\types\repair_ca.paa", {[btc_create_object_point] spawn btc_fnc_log_garage}, {(serverCommandAvailable "#logout" || isMultiplayer) and btc_p_garage}, {}, [], [0,0,0], 5] call ace_interact_menu_fnc_createAction;
+[btc_create_object, 0, ["ACE_MainActions","Logistic"], _action] call ace_interact_menu_fnc_addActionToObject;
 
 //Logistic
 _action = ["Logistic","Logistic","\A3\ui_f\data\igui\cfg\simpleTasks\letters\L_ca.paa",{},{true}] call ace_interact_menu_fnc_createAction;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
@@ -1,0 +1,24 @@
+
+private _type = _this select 0;
+private _pos = _this select 1;
+private _dir = _this select 2;
+if (count _this > 3) then {
+	private _textures = _this select 4;
+} else {
+	private _textures = nil;
+};
+
+_veh  = createVehicle [_type, [_pos select 0, _pos select 1, 0], [], 0, "CAN_COLLIDE"];
+_veh setPosASL _pos;
+_veh setDir _dir;
+
+if !(isNull _textures) then {{_veh setObjectTextureGlobal [ _foreachindex, _x ];} forEach _textures;};
+_veh setVariable ["btc_dont_delete",true];
+
+if(getNumber(configFile >> "CfgVehicles" >> typeof _veh >> "isUav")==1) then {
+	createVehicleCrew _veh;
+};
+
+_veh call btc_fnc_db_add_veh;
+
+_veh

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
@@ -2,20 +2,18 @@
 private _type = _this select 0;
 private _pos = _this select 1;
 private _dir = _this select 2;
-if (count _this > 3) then {
-	private _textures = _this select 4;
-} else {
-	private _textures = nil;
-};
+private _textures = if (count _this > 3) then {_this select 3} else {[]};
 
 _veh  = createVehicle [_type, [_pos select 0, _pos select 1, 0], [], 0, "CAN_COLLIDE"];
 _veh setPosASL _pos;
 _veh setDir _dir;
 
-if !(isNull _textures) then {{_veh setObjectTextureGlobal [ _foreachindex, _x ];} forEach _textures;};
+{
+	_veh setObjectTextureGlobal [ _foreachindex, _x ];
+} forEach _textures;
 _veh setVariable ["btc_dont_delete",true];
 
-if(getNumber(configFile >> "CfgVehicles" >> typeof _veh >> "isUav")==1) then {
+if (getNumber(configFile >> "CfgVehicles" >> typeof _veh >> "isUav") isEqualTo 1) then {
 	createVehicleCrew _veh;
 };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/garage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/garage.sqf
@@ -1,0 +1,28 @@
+
+if (count (nearestObjects [getpos btc_log_create_obj,["All"],5]) > 1) exitWith {hint "Clear the area before create another object!"};
+
+disableSerialization;
+uiNamespace setVariable [ "current_garage", ( _this select 0 ) ];
+private _fullVersion = missionNamespace getVariable [ "BIS_fnc_arsenal_fullGarage", false ];
+if !( isNull ( uiNamespace getVariable [ "BIS_fnc_arsenal_cam", objNull ] ) ) exitwith { "Garage Viewer is already running" call bis_fnc_logFormat; };
+{ deleteVehicle _x; } forEach nearestObjects [ getPos ( _this select 0 ), [ "AllVehicles" ], 10 ];
+private _veh = createVehicle [ "Land_HelipadEmpty_F", getPos ( _this select 0 ), [], 0, "CAN_COLLIDE" ];
+_veh setPosASL getPosASL ( _this select 0 );
+uiNamespace setVariable [ "garage_pad", _veh ];
+missionNamespace setVariable [ "BIS_fnc_arsenal_fullGarage", [ true, 0, false, [ false ] ] call bis_fnc_param ];
+with missionNamespace do { BIS_fnc_garage_center = _veh };
+with uiNamespace do {
+	private _displayMission = [] call ( uiNamespace getVariable "bis_fnc_displayMission" );
+	if !( isNull findDisplay 312 ) then { _displayMission = findDisplay 312; };
+	_displayMission createDisplay "RscDisplayGarage";
+	uiNamespace setVariable [ "running_garage", true ];
+	waitUntil { sleep 0.25; isNull ( uiNamespace getVariable [ "BIS_fnc_arsenal_cam", objNull ] ) };
+	private _logistic_point = uiNamespace getVariable "current_garage";
+	private _pad = uiNamespace getVariable "garage_pad";
+	deleteVehicle _pad;
+	private _veh_list = ( getPos _logistic_point ) nearEntities 5;
+	{
+		{deleteVehicle _x;} forEach crew _x;
+		[[_x], {[_this select 0] call btc_fnc_log_server_repair_wreck}] remoteExec ["call", 2];
+	} forEach _veh_list;
+};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/garage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/garage.sqf
@@ -29,6 +29,6 @@ with uiNamespace do {
 		private _textures = getObjectTextures _x;
 		deleteVehicle _x;
 		[_type, _pos, _dir, _textures] remoteExec ["btc_fnc_log_createVehicle", 2];
-		[_type] remoteExec [["btc_fnc_eh_veh_init", -2];
+		[_type] remoteExec ["btc_fnc_eh_veh_init", -2];
 	} forEach _veh_list;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/garage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/garage.sqf
@@ -1,11 +1,10 @@
 
-if (count (nearestObjects [getpos btc_log_create_obj,["All"],5]) > 1) exitWith {hint "Clear the area before create another object!"};
+if (count (nearestObjects [getpos ( _this select 0 ),["All"],5]) > 1) exitWith {hint "Clear the area before create another object!"};
 
 disableSerialization;
 uiNamespace setVariable [ "current_garage", ( _this select 0 ) ];
 private _fullVersion = missionNamespace getVariable [ "BIS_fnc_arsenal_fullGarage", false ];
 if !( isNull ( uiNamespace getVariable [ "BIS_fnc_arsenal_cam", objNull ] ) ) exitwith { "Garage Viewer is already running" call bis_fnc_logFormat; };
-{ deleteVehicle _x; } forEach nearestObjects [ getPos ( _this select 0 ), [ "AllVehicles" ], 10 ];
 private _veh = createVehicle [ "Land_HelipadEmpty_F", getPos ( _this select 0 ), [], 0, "CAN_COLLIDE" ];
 _veh setPosASL getPosASL ( _this select 0 );
 uiNamespace setVariable [ "garage_pad", _veh ];
@@ -23,6 +22,12 @@ with uiNamespace do {
 	private _veh_list = ( getPos _logistic_point ) nearEntities 5;
 	{
 		{deleteVehicle _x;} forEach crew _x;
-		[[_x], {[_this select 0] call btc_fnc_log_server_repair_wreck}] remoteExec ["call", 2];
+
+		private _type = typeOf _x;
+		private _pos = getPosASL _x;
+		private _dir = getDir _x;
+		private _textures = getObjectTextures _x;
+		deleteVehicle _x;
+		[[_type, _pos, _dir, _textures], {_this call btc_fnc_log_createVehicle}] remoteExec ["call", 2];
 	} forEach _veh_list;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/garage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/garage.sqf
@@ -28,6 +28,7 @@ with uiNamespace do {
 		private _dir = getDir _x;
 		private _textures = getObjectTextures _x;
 		deleteVehicle _x;
-		[[_type, _pos, _dir, _textures], {_this call btc_fnc_log_createVehicle}] remoteExec ["call", 2];
+		[_type, _pos, _dir, _textures] remoteExec ["btc_fnc_log_createVehicle", 2];
+		[_type] remoteExec [["btc_fnc_eh_veh_init", -2];
 	} forEach _veh_list;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
@@ -1,10 +1,11 @@
 
-private ["_veh","_type","_pos","_dir","_marker"];
+private ["_veh","_type","_pos","_dir","_marker","_textures"];
 
 _veh = _this select 0;
 _type = typeOf _veh;
 _pos = getPos _veh;
 _dir = getDir _veh;
+_textures = getObjectTextures _veh;
 _marker = _veh getVariable ["marker",""];
 
 btc_vehicles = btc_vehicles - [_veh];
@@ -14,6 +15,7 @@ deleteVehicle _veh;
 sleep 1;
 _veh  = createVehicle [_type, [_pos select 0, _pos select 1, 0], [], 0, "CAN_COLLIDE"];
 _veh setDir _dir;
+{_veh setObjectTexture [ _foreachindex, _x ];} forEach _textures;
 _veh setVariable ["btc_dont_delete",true];
 
 if ((isNumber (configfile >> "CfgVehicles" >> typeof _veh >> "ace_fastroping_enabled")) && !(typeof _veh isEqualTo "RHS_UH1Y_d")) then {[_veh] call ace_fastroping_fnc_equipFRIES};
@@ -21,4 +23,4 @@ if(getNumber(configFile >> "CfgVehicles" >> typeof _veh >> "isUav")==1) then {
 	createVehicleCrew _veh;
 };
 
-btc_vehicles = btc_vehicles + [_veh];
+btc_vehicles pushBack _veh;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
@@ -3,7 +3,7 @@ private ["_veh","_type","_pos","_dir","_marker","_textures"];
 
 _veh = _this select 0;
 _type = typeOf _veh;
-_pos = getPos _veh;
+_pos = getPosASL _veh;
 _dir = getDir _veh;
 _textures = getObjectTextures _veh;
 _marker = _veh getVariable ["marker",""];
@@ -13,13 +13,6 @@ btc_vehicles = btc_vehicles - [_veh];
 if (_marker != "") then {deleteMarker _marker;};
 deleteVehicle _veh;
 sleep 1;
-_veh  = createVehicle [_type, [_pos select 0, _pos select 1, 0], [], 0, "CAN_COLLIDE"];
-_veh setDir _dir;
-{_veh setObjectTexture [ _foreachindex, _x ];} forEach _textures;
-_veh setVariable ["btc_dont_delete",true];
+_veh = [_type,_pos,_dir,_textures] call btc_fnc_log_createVehicle;
 
-if(getNumber(configFile >> "CfgVehicles" >> typeof _veh >> "isUav")==1) then {
-	createVehicleCrew _veh;
-};
-
-_veh call btc_fnc_db_add_veh;
+_veh


### PR DESCRIPTION
https://github.com/Vdauphin/HeartsAndMinds/issues/224

It is not easy to add vehicles inside H&M system (wreck, logistic, database etc) when the game is running.
This will add the possibility to admin to create a vehicle directly with logistic box. It is available for Admin only (by default it will be desactivate).

- [x] add interaction to the new vehicle
- [x] test dedicate compatibility 
- [x] switch `btc_p_garage` to `false` by default 

Final test :
- [x] local
- [x] server