### PR TITLE
FIX: pilot not being removed at the end of rescue mission

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
@@ -81,6 +81,10 @@ if (btc_side_aborted || btc_side_failed || ({Alive _x} count _units isEqualTo 0)
 
 50 call btc_fnc_rep_change;
 
+{
+    deleteVehicle _x;
+} foreach _units;
+
 [13,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
 
 btc_side_assigned = false;publicVariable "btc_side_assigned";


### PR DESCRIPTION
FIX: Pilot not being removed at the end of rescue mission.

Because we started feeling bad for shooting him after rescuing the poor sod. ;)

Final test :
- [x] local
- [x] server