### PR TITLE
FIX: Task notification appear to everybody when a player is connecting

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/end_mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/end_mission.sqf
@@ -1,4 +1,4 @@
-0 spawn btc_fnc_task_set_done;
+0 call btc_fnc_task_set_done;
 
 hint "All the hideouts are destroyed, finally the Oplitas has been defeated! Mission accomplished";
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/final_phase.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/final_phase.sqf
@@ -3,7 +3,7 @@ private ["_radius_x","_radius_y","_marker"];
 
 [[6],"btc_fnc_show_hint"] spawn BIS_fnc_MP;
 
-[1,"btc_fnc_task_set_done",true,true] spawn BIS_fnc_MP;
+{1 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 btc_final_phase = true;
 
@@ -26,7 +26,7 @@ btc_city_remaining = [];
 
 waitUntil {sleep 15; (btc_city_remaining isEqualTo [])};
 
-[0,"btc_fnc_task_set_done",true,true] spawn BIS_fnc_MP;
+{0 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 //END
 [[],"btc_fnc_end_mission",true,true] spawn BIS_fnc_MP;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/final_phase.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/final_phase.sqf
@@ -26,7 +26,7 @@ btc_city_remaining = [];
 
 waitUntil {sleep 15; (btc_city_remaining isEqualTo [])};
 
-{0 call btc_fnc_task_set_done} remoteExec ["call", 0];
+{{_x call btc_fnc_task_set_done} foreach [0,2];} remoteExec ["call", 0];
 
 //END
 [[],"btc_fnc_end_mission",true,true] spawn BIS_fnc_MP;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/final_phase.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/final_phase.sqf
@@ -26,7 +26,8 @@ btc_city_remaining = [];
 
 waitUntil {sleep 15; (btc_city_remaining isEqualTo [])};
 
-{{_x call btc_fnc_task_set_done} foreach [0,2];} remoteExec ["call", 0];
+{0 call btc_fnc_task_set_done;} remoteExec ["call", 0];
+2 call btc_fnc_task_set_done;
 
 //END
 [[],"btc_fnc_end_mission",true,true] spawn BIS_fnc_MP;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -197,6 +197,12 @@ btc_fnc_log_tow = compile preprocessFile "core\fnc\log\tow.sqf";
 btc_fnc_log_unhook = compile preprocessFile "core\fnc\log\unhook.sqf";
 btc_fnc_log_unload = compile preprocessFile "core\fnc\log\unload.sqf";
 
+
+//TASK
+btc_fnc_task_create = compile preprocessFileLineNumbers "core\fnc\task\create.sqf";
+btc_fnc_task_fail = compile preprocessFileLineNumbers "core\fnc\task\fail.sqf";
+btc_fnc_task_set_done = compile preprocessFileLineNumbers "core\fnc\task\set_done.sqf";
+
 //SIDE
 btc_fnc_side_abort = compile preprocessFileLineNumbers "core\fnc\side\abort.sqf";
 
@@ -237,11 +243,6 @@ if (!isDedicated) then {
 	btc_fnc_info_search_for_intel = compile preprocessFile "core\fnc\info\search_for_intel.sqf";
 	btc_fnc_info_troops = compile preprocessFile "core\fnc\info\troops.sqf";
 	btc_fnc_info_ask_reputation = compile preprocessFile "core\fnc\info\ask_reputation.sqf";
-
-	//TASK
-	btc_fnc_task_create = compile preprocessFileLineNumbers "core\fnc\task\create.sqf";
-	btc_fnc_task_fail = compile preprocessFileLineNumbers "core\fnc\task\fail.sqf";
-	btc_fnc_task_set_done = compile preprocessFileLineNumbers "core\fnc\task\set_done.sqf";
 
 	//SIDE
 	btc_fnc_side_request = compile preprocessFileLineNumbers "core\fnc\side\request.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/capture_officer.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/capture_officer.sqf
@@ -29,7 +29,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[14,getPos _city1,_city1 getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[14,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [14,getPos _city1,_city1 getVariable "name"];
 
@@ -111,7 +111,7 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || !(Alive _captive) ||
 {deletemarker _x} foreach _markers;
 
 if (btc_side_aborted || !(Alive _captive)) exitWith {
-	[14,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{14 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 	[_vehs + [_trigger],_group] spawn {
 		waitUntil {sleep 5; ({_x distance ((_this select 0) select 0) < 500} count playableUnits isEqualTo 0)};
@@ -135,7 +135,7 @@ if (btc_side_failed) exitWith {
 
 50 call btc_fnc_rep_change;
 
-[14,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{14 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 [_vehs + [_trigger],_group] spawn {
 	waitUntil {sleep 5; ({_x distance ((_this select 0) select 0) < 500} count playableUnits isEqualTo 0)};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/checkpoint.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/checkpoint.sqf
@@ -12,7 +12,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[9,_pos,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[9,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [9,_pos,_city getVariable "name"];
 
@@ -90,7 +90,7 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || ({Alive _x} count _b
 {deletemarker _x} foreach _markers;
 
 if (btc_side_aborted || btc_side_failed ) exitWith {
-	[9,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{9 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 	{
 		_x spawn {
@@ -102,7 +102,7 @@ if (btc_side_aborted || btc_side_failed ) exitWith {
 
 80 call btc_fnc_rep_change;
 
-[9,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{9 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 {
 	_x spawn {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/civtreatment.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/civtreatment.sqf
@@ -26,7 +26,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[8,_pos,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[8,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [8,_pos,_city getVariable "name"];
 
@@ -88,13 +88,13 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || !Alive _unit || {_un
 };
 
 if (btc_side_aborted || btc_side_failed || !Alive _unit) exitWith {
-	[8,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{8 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 };
 
 10 call btc_fnc_rep_change;
 
-[8,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{8 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 _unit setUnitPos "UP";
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/civtreatment_boat.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/civtreatment_boat.sqf
@@ -17,7 +17,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[10,_vehpos,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[10,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [10,_vehpos,_city getVariable "name"];
 
@@ -52,7 +52,7 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || !Alive _unit || {_un
 {deletemarker _x} foreach [_marker];
 
 if (btc_side_aborted || btc_side_failed || !Alive _unit) exitWith {
-	[10,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{10 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 	{_x spawn {
 	waitUntil {sleep 5; ({_x distance _this < 300} count playableUnits == 0)};
@@ -62,7 +62,7 @@ if (btc_side_aborted || btc_side_failed || !Alive _unit) exitWith {
 
 10 call btc_fnc_rep_change;
 
-[10,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{10 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 {_x spawn {
 	waitUntil {sleep 5; ({_x distance _this < 300} count playableUnits == 0)};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/convoy.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/convoy.sqf
@@ -26,7 +26,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[12,_pos1,_city2 getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[12,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [12,_pos1,_city1 getVariable "name"];
 
@@ -106,7 +106,7 @@ if (btc_side_aborted) exitWith {
 };
 
 if (btc_side_failed) exitWith {
-	[12,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{12 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 	_group setVariable ["no_cache",false];
 	{
@@ -118,7 +118,7 @@ if (btc_side_failed) exitWith {
 
 50 call btc_fnc_rep_change;
 
-[12,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{12 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 [_vehs,_group] spawn {
 	waitUntil {sleep 5; ({_x distance ((_this select 0) select 0) < 500} count playableUnits isEqualTo 0)};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/get_city.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/get_city.sqf
@@ -13,7 +13,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[6,_pos,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[6,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [6,_pos,_city getVariable "name"];
 
@@ -23,12 +23,12 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || !(_city getVariable 
 
 
 if (btc_side_aborted || btc_side_failed) exitWith {
-	[6,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{6 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 };
 
 80 call btc_fnc_rep_change;
 
-[6,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{6 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 btc_side_assigned = false;publicVariable "btc_side_assigned";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
@@ -24,7 +24,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[15,getPos _city,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[15,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [15,getPos _city,_city getVariable "name"];
 
@@ -80,7 +80,7 @@ _group_civ setVariable ["no_cache",false];
 {_x setVariable ["no_cache",false];} foreach _group;
 
 if (btc_side_aborted || btc_side_failed || !(Alive _captive)) exitWith {
-	[15,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{15 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 	[[_captive,_trigger,_mine],_group_civ,_group] spawn {
 		waitUntil {sleep 5; ({_x distance (_this select 0 select 0) < 500} count playableUnits isEqualTo 0)};
@@ -94,6 +94,6 @@ if (btc_side_aborted || btc_side_failed || !(Alive _captive)) exitWith {
 
 40 call btc_fnc_rep_change;
 
-[15,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{15 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 btc_side_assigned = false;publicVariable "btc_side_assigned";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/mines.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/mines.sqf
@@ -15,7 +15,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[4,_pos,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[4,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [4,_pos,_city getVariable "name"];
 
@@ -54,13 +54,13 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || ({!isNull _x} count 
 {deletemarker _x} foreach [_area,_marker];
 
 if (btc_side_aborted || btc_side_failed) exitWith {
-	[4,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{4 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 	{if (!isNull _x) then {deleteVehicle _x}} foreach _mines;
 };
 
 30 call btc_fnc_rep_change;
 
-[4,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{4 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 btc_side_assigned = false;publicVariable "btc_side_assigned";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
@@ -23,7 +23,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[13,getPos _city,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[13,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [13,getPos _city,_city getVariable "name"];
 
@@ -75,12 +75,12 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || ({_x distance getpos
 };
 
 if (btc_side_aborted || btc_side_failed || ({Alive _x} count _units isEqualTo 0)) exitWith {
-	[13,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{13 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 };
 
 50 call btc_fnc_rep_change;
 
-[13,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{13 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 btc_side_assigned = false;publicVariable "btc_side_assigned";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/supply.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/supply.sqf
@@ -15,7 +15,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[3,_pos,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[3,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [3,_pos,_city getVariable "name"];
 
@@ -36,13 +36,13 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || count (nearestObject
 {deletemarker _x} foreach [_area,_marker];
 
 if (btc_side_aborted || btc_side_failed) exitWith {
-	[3,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{3 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 };
 
 50 call btc_fnc_rep_change;
 
-[3,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{3 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 if (count (nearestObjects [_pos, [btc_supplies_mat], 30]) > 0) then {
 	_pos spawn {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/tower.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/tower.sqf
@@ -21,7 +21,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[7,_pos,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[7,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [7,_pos,_city getVariable "name"];
 
@@ -62,7 +62,7 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || !Alive _tower )};
 {deletemarker _x} foreach [_area,_marker];
 
 if (btc_side_aborted || btc_side_failed ) exitWith {
-	[7,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{7 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 	_btc_composition spawn {
 
@@ -74,7 +74,7 @@ if (btc_side_aborted || btc_side_failed ) exitWith {
 
 80 call btc_fnc_rep_change;
 
-[7,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{7 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 _btc_composition spawn {
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/underwater_generator.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/underwater_generator.sqf
@@ -30,7 +30,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[11,_pos,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[11,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [11,_pos,_city getVariable "name"];
 
@@ -59,7 +59,7 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || !Alive _generator )}
 {deletemarker _x} foreach [_area,_marker];
 
 if (btc_side_aborted || btc_side_failed ) exitWith {
-	[11,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{11 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 	{_x spawn {
 
@@ -71,7 +71,7 @@ if (btc_side_aborted || btc_side_failed ) exitWith {
 
 80 call btc_fnc_rep_change;
 
-[11,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{11 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 {_x spawn {
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/vehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/vehicle.sqf
@@ -16,7 +16,7 @@ btc_side_done = false;
 btc_side_failed = false;
 btc_side_assigned = true;publicVariable "btc_side_assigned";
 
-[[5,_pos,_city getVariable "name"],"btc_fnc_task_create",true] spawn BIS_fnc_MP;
+[5,_pos,_city getVariable "name"] call btc_fnc_task_create;
 
 btc_side_jip_data = [5,_pos,_city getVariable "name"];
 
@@ -46,13 +46,13 @@ waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || (_veh getHit "wheel_
 {deletemarker _x} foreach [_area,_marker];
 
 if (btc_side_aborted || btc_side_failed || !Alive _veh) exitWith {
-	[5,"btc_fnc_task_fail",true] spawn BIS_fnc_MP;
+	{5 call btc_fnc_task_fail} remoteExec ["call", 0];
 	btc_side_assigned = false;publicVariable "btc_side_assigned";
 };
 
 15 call btc_fnc_rep_change;
 
-[5,"btc_fnc_task_set_done",true] spawn BIS_fnc_MP;
+{5 call btc_fnc_task_set_done} remoteExec ["call", 0];
 
 _veh spawn {
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
@@ -3,6 +3,8 @@ if (!isServer) exitWith {["task" + ([_this select 0] call BIS_fnc_taskState) + "
 
 private ["_location","_destination","_description","_type"];
 
+if ((typeName (_this select 0)) isEqualTo "STRING") exitWith {};
+
 if (count _this > 1) then {
 	_destination = _this select 1;
 	_location = _this select 2;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
@@ -1,6 +1,7 @@
-if (isDedicated) exitWith {};
 
-private ["_location","_destination"];
+if (!isDedicated) exitWith {["task" + "CREATED" + "Icon",[[[_this select 0] call BIS_fnc_taskType] call bis_fnc_taskTypeIcon, ([_this select 0] call BIS_fnc_taskDescription) select 1 select 0]] call bis_fnc_showNotification;};
+
+private ["_location","_destination","_description","_type"];
 
 if (count _this > 1) then {
 	_destination = _this select 1;
@@ -14,62 +15,84 @@ switch (_this select 0) do
 {
 	case 0 :
 	{
-		[player,["task_0"],["Destroy all the hideouts of the Oplitas and defeat them once and for all","Defeat the Oplitas","Defeat the Oplitas"],_destination,true,2,true,"kill",true] call BIS_fnc_taskCreate;
+		_description = ["Destroy all the hideouts of the Oplitas and defeat them once and for all","Defeat the Oplitas","Defeat the Oplitas"];
+		_type = "kill";
 	};
 	case 1 :
 	{
-		[player,["task_1"],["Destroy all the hideouts of the Oplitas and defeat them once and for all","Destroy all the hideouts","Destroy all the hideouts"],_destination,true,1,true,"destroy",true] call BIS_fnc_taskCreate;
+		_description = ["Destroy all the hideouts of the Oplitas and defeat them once and for all","Destroy all the hideouts","Destroy all the hideouts"];
+		_type = "destroy";
+	};
+	case 2 :
+	{
+		_description = ["Seize the last positions held by the enemies","Size the last enemies positions","Seize the last enemies positions"];
+		_type = "move";
 	};
 	case 3 :
 	{
-		[player,["task_3"],[format ["The citizens of %1 are starving to death, bring them some supplies present at the logisitic point!",_location],("Supply " + _location),("Supply " + _location)],_destination,true,3,true,"move",true] call BIS_fnc_taskCreate;
+		_description = [format ["The citizens of %1 are starving to death, bring them some supplies present at the logisitic point!",_location],("Supply " + _location),("Supply " + _location)];
+		_type = "move";
 	};
 	case 4 :
 	{
-		[player,["task_4"],[format ["There is a minefield near %1, clear it!",_location],("Minefield near " + _location),("Minefield near " + _location)],_destination,true,3,true,"search",true] call BIS_fnc_taskCreate;
+		_description = [format ["There is a minefield near %1, clear it!",_location],("Minefield near " + _location),("Minefield near " + _location)];
+		_type = "search";
 	};
 	case 5 :
 	{
-		[player,["task_5"],[format ["A vehicle damaged by an IED needs assistance near %1! Repair it!",_location],("Vehicle needs assistance near " + _location),("Vehicle needs assistance near " + _location)],_destination,true,3,true,"repair",true] call BIS_fnc_taskCreate;
+		_description = [format ["A vehicle damaged by an IED needs assistance near %1! Repair it!",_location],("Vehicle needs assistance near " + _location),("Vehicle needs assistance near " + _location)];
+		_type = "repair";
 	};
 	case 6 :
 	{
-		[player,["task_6"],[format ["%1 has been conquered by the Oplitas! Local population is terrorised and is asking for your help!",_location],("Free " + _location),("Free " + _location)],_destination,true,3,true,"attack",true] call BIS_fnc_taskCreate;
+		_description = [format ["%1 has been conquered by the Oplitas! Local population is terrorised and is asking for your help!",_location],("Free " + _location),("Free " + _location)];
+		_type = "attack";
 	};
 	case 7 :
 	{
-		[player,["task_7"],[format ["A Oplitas radio tower has been located in %1. Local population is asking for your help to destroy it! (Use one M183 explosive satchel)",_location],("Destroy tower in " + _location),("Destroy tower in " + _location)],_destination,true,3,true,"destroy",true] call BIS_fnc_taskCreate;
+		_description = [format ["A Oplitas radio tower has been located in %1. Local population is asking for your help to destroy it! (Use one M183 explosive satchel)",_location],("Destroy tower in " + _location),("Destroy tower in " + _location)];
+		_type = "destroy";
 	};
 	case 8 :
 	{
-		[player,["task_8"],[format ["A civilian is calling for a medic in %1, treat and wait for patient stabilization ",_location],("Medical emergency call in " + _location),("Medical emergency call in " + _location)],_destination,true,3,true,"heal",true] call BIS_fnc_taskCreate;
+		_description = [format ["A civilian is calling for a medic in %1, treat and wait for patient stabilization ",_location],("Medical emergency call in " + _location),("Medical emergency call in " + _location)];
+		_type = "heal";
 	};
 	case 9 :
 	{
-		[player,["task_9"],[format ["Checkpoints has been located in %1. Local population is asking for your help to destroy ammo box in all checkpoints!",_location],("Destroy checkpoints in " + _location),("Destroy checkpoints in " + _location)],_destination,true,3,true,"destroy",true] call BIS_fnc_taskCreate;
+		_description = [format ["Checkpoints has been located in %1. Local population is asking for your help to destroy ammo box in all checkpoints!",_location],("Destroy checkpoints in " + _location),("Destroy checkpoints in " + _location)];
+		_type = "destroy";
 	};
 	case 10 :
 	{
-		[player,["task_10"],[format ["A civilian is calling for a medic in %1, treat and wait for patient stabilization ",_location],("Medical emergency call in " + _location),("Medical emergency call in " + _location)],_destination,true,3,true,"heal",true] call BIS_fnc_taskCreate;
+		_description = [format ["A civilian is calling for a medic in %1, treat and wait for patient stabilization ",_location],("Medical emergency call in " + _location),("Medical emergency call in " + _location)];
+		_type = "heal";
 	};
 	case 11 :
 	{
-		[player,["task_11"],[format ["Underwater generator has been located in %1. Local population is asking for your help to destroy it!",_location],("Destroy underwater generator in " + _location),("Destroy underwater generator in " + _location)],_destination,true,3,true,"destroy",true] call BIS_fnc_taskCreate;
+		_description = [format ["Underwater generator has been located in %1. Local population is asking for your help to destroy it!",_location],("Destroy underwater generator in " + _location),("Destroy underwater generator in " + _location)];
+		_type = "destroy";
 	};
 	case 12 :
 	{
-		[player,["task_12"],[format ["An armed convoy is going to attack %1. Local population is asking for your help to destroy it before!",_location],("Destroy a convoy attacking " + _location),("Destroy a convoy attacking " + _location)],_destination,true,3,true,"attack",true] call BIS_fnc_taskCreate;
+		_description = [format ["An armed convoy is going to attack %1. Local population is asking for your help to destroy it before!",_location],("Destroy a convoy attacking " + _location),("Destroy a convoy attacking " + _location)];
+		_type = "attack";
 	};
 	case 13 :
 	{
-		[player,["task_13"],[format ["A pilot crashed his helicopter near %1. He is asking for your help to rescue him back to base!",_location],("Rescue a pilot near " + _location),("Rescue a pilot near " + _location)],_destination,true,3,true,"navigate",true] call BIS_fnc_taskCreate;
+		_description = [format ["A pilot crashed his helicopter near %1. He is asking for your help to rescue him back to base!",_location],("Rescue a pilot near " + _location),("Rescue a pilot near " + _location)];
+		_type = "navigate";
 	};
 	case 14 :
 	{
-		[player,["task_14"],[format ["Capture an officer travelling in a secret and fast convoy, then bring him at base. He is terrorising local population!",_location],("Capture officer in secret fast convoy"),("Capture officer in secret fast convoy")],_destination,true,3,true,"run",true] call BIS_fnc_taskCreate;
+		_description = [format ["Capture an officer travelling in a secret and fast convoy, then bring him at base. He is terrorising local population!",_location],("Capture officer in secret fast convoy"),("Capture officer in secret fast convoy")];
+		_type = "run";
 	};
 	case 15 :
 	{
-		[player,["task_15"],[format ["Liberate a civilian hostage in %1. Local population is asking for your help!",_location],("Liberate hostage near " + _location),("Liberate hostage near " + _location)],_destination,true,3,true,"exit",true] call BIS_fnc_taskCreate;
+		_description = [format ["Liberate a civilian hostage in %1. Local population is asking for your help!",_location],("Liberate hostage near " + _location),("Liberate hostage near " + _location)];
+		_type = "exit";
 	};
 };
+
+[btc_player_side,[str((_this select 0))],_description,_destination,true,2,true,_type,true] call BIS_fnc_taskCreate;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
@@ -15,17 +15,17 @@ switch (_this select 0) do
 {
 	case 0 :
 	{
-		_description = ["Destroy all the hideouts of the Oplitas and defeat them once and for all","Defeat the Oplitas","Defeat the Oplitas"];
+		_description = ["Defeat the Oplitas once and for all","Defeat the Oplitas","Defeat the Oplitas"];
 		_type = "kill";
 	};
 	case 1 :
 	{
-		_description = ["Destroy all the hideouts of the Oplitas and defeat them once and for all","Destroy all the hideouts","Destroy all the hideouts"];
+		_description = ["Destroy all the hideouts of the Oplitas","Destroy all the hideouts","Destroy all the hideouts"];
 		_type = "destroy";
 	};
 	case 2 :
 	{
-		_description = ["Seize the last positions held by the enemies","Size the last enemies positions","Seize the last enemies positions"];
+		_description = ["Seize the last positions held by the enemies","Seize the last enemies positions","Seize the last enemies positions"];
 		_type = "move";
 	};
 	case 3 :

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
@@ -1,5 +1,5 @@
 
-if (!isDedicated) exitWith {["task" + "CREATED" + "Icon",[[[_this select 0] call BIS_fnc_taskType] call bis_fnc_taskTypeIcon, ([_this select 0] call BIS_fnc_taskDescription) select 1 select 0]] call bis_fnc_showNotification;};
+if (!isDedicated) exitWith {["task" + ([_this select 0] call BIS_fnc_taskState) + "Icon",[[[_this select 0] call BIS_fnc_taskType] call bis_fnc_taskTypeIcon, ([_this select 0] call BIS_fnc_taskDescription) select 1 select 0]] call bis_fnc_showNotification;};
 
 private ["_location","_destination","_description","_type"];
 
@@ -95,4 +95,4 @@ switch (_this select 0) do
 	};
 };
 
-[btc_player_side,[str((_this select 0))],_description,_destination,true,2,true,_type,true] call BIS_fnc_taskCreate;
+[btc_player_side,[str(_this select 0)],_description,_destination,true,2,true,_type,true] call BIS_fnc_taskCreate;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
@@ -1,5 +1,5 @@
 
-if (!isDedicated) exitWith {["task" + ([_this select 0] call BIS_fnc_taskState) + "Icon",[[[_this select 0] call BIS_fnc_taskType] call bis_fnc_taskTypeIcon, ([_this select 0] call BIS_fnc_taskDescription) select 1 select 0]] call bis_fnc_showNotification;};
+if (!isServer) exitWith {["task" + ([_this select 0] call BIS_fnc_taskState) + "Icon",[[[_this select 0] call BIS_fnc_taskType] call bis_fnc_taskTypeIcon, ([_this select 0] call BIS_fnc_taskDescription) select 1 select 0]] call bis_fnc_showNotification;};
 
 private ["_location","_destination","_description","_type"];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/fail.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/fail.sqf
@@ -58,4 +58,4 @@ switch _this do
 		_description = ["Side mission failed!","The hostage has not been liberated"];
 	};
 };
-["TaskFailed",_description] call bis_fnc_showNotification;
+["task" + "FAILED" + "Icon",[[[str(_this)] call BIS_fnc_taskType] call bis_fnc_taskTypeIcon, _description select 1]] call bis_fnc_showNotification;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/fail.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/fail.sqf
@@ -1,109 +1,61 @@
-if (isDedicated) exitWith {};
+
+if (isServer) exitWith {[str(_this), "FAILED",false] spawn BIS_fnc_taskSetState;};
+
+private ["_description"];
 
 switch _this do
 {
 	case 3 :
 	{
-		private "_task";
-		_task = player getVariable ( "task_3" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","Supplies have not been delivered"]] call bis_fnc_showNotification;
-		player setVariable [("task_3" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","Supplies have not been delivered"];
 	};
 	case 4 :
 	{
-		private "_task";
-		_task = player getVariable ( "task_4" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The minefield has not been cleared"]] call bis_fnc_showNotification;
-		player setVariable [("task_4" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The minefield has not been cleared"];
 	};
 	case 5 :
 	{
-		private "_task";
-		_task = player getVariable ( "task_5" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The vehicle has not been repaired"]] call bis_fnc_showNotification;
-		player setVariable [("task_5" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The vehicle has not been repaired"];
 	};
 	case 6 :
 	{
-		private "_task";
-		_task = player getVariable ( "task_6" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The city has not been conquered"]] call bis_fnc_showNotification;
-		player setVariable [("task_6" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The city has not been conquered"];
 	};
 	case 7 :
 	{
-		private "_task";
-		_task = player getVariable ( "task_7" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The tower has not been destroyed"]] call bis_fnc_showNotification;
-		player setVariable [("task_7" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The tower has not been destroyed"];
 	};
 	case 8 :
 	{
-		private "_task";
-		_task = player getVariable ( "task_8" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The patient has not been stabilized"]] call bis_fnc_showNotification;
-		player setVariable [("task_8" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The patient has not been stabilized"];
 	};
 	case 9 :
 	{
-		private "_task";
-		_task = player getVariable ( "task_9" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","Checkpoints have not been destroyed"]] call bis_fnc_showNotification;
-		player setVariable [("task_9" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","Checkpoints have not been destroyed"];
 	};
 	case 10 :
 	{
-		private "_task";
-		_task = player getVariable ("task_10" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The patient has not been stabilized"]] call bis_fnc_showNotification;
-		player setVariable [("task_10" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The patient has not been stabilized"];
 	};
 	case 11 :
 	{
-		private "_task";
-		_task = player getVariable ("task_11" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The underwater generator has not been destroyed"]] call bis_fnc_showNotification;
-		player setVariable [("task_11" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The underwater generator has not been destroyed"];
 	};
 	case 12 :
 	{
-		private "_task";
-		_task = player getVariable ("task_12" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The armed convoy has not been destroyed"]] call bis_fnc_showNotification;
-		player setVariable [("task_12" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The armed convoy has not been destroyed"];
 	};
 	case 13 :
 	{
-		private "_task";
-		_task = player getVariable ("task_13" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The pilot has not been rescued"]] call bis_fnc_showNotification;
-		player setVariable [("task_13" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The pilot has not been rescued"];
 	};
 	case 14 :
 	{
-		private "_task";
-		_task = player getVariable ("task_14" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The officer has not been captured"]] call bis_fnc_showNotification;
-		player setVariable [("task_14" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The officer has not been captured"];
 	};
 	case 15 :
 	{
-		private "_task";
-		_task = player getVariable ("task_15" call bis_fnc_taskVar);
-		_task setTaskState "FAILED";
-		["TaskFailed",["Side mission failed!","The hostage has not been liberated"]] call bis_fnc_showNotification;
-		player setVariable [("task_15" call bis_fnc_taskVar),nil];
+		_description = ["Side mission failed!","The hostage has not been liberated"];
 	};
 };
+["TaskFailed",_description] call bis_fnc_showNotification;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/set_done.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/set_done.sqf
@@ -14,6 +14,9 @@ switch _this do
 	case 1 : {
 		_description = ["Misison accomplished!","All the hideouts have been destroyed!"];
 	};
+	case 2 : {
+		_description = ["Misison accomplished!","Oplitas has been finally defeated!    Misison accomplished!"];
+	};
 	case 3 : {
 		_description = ["Side mission Accomplished!","Supplies have been delivered"];
 	};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/set_done.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/set_done.sqf
@@ -1,7 +1,7 @@
 
 if (isServer) exitWith {
 	[str(_this), "SUCCEEDED",false] spawn BIS_fnc_taskSetState;
-	if (_this isEqualTo 1) then {[2] spawn btc_fnc_task_create};
+	if (_this isEqualTo 1) then {[2] call btc_fnc_task_create};
 };
 
 private ["_description"];
@@ -54,4 +54,4 @@ switch _this do
 		_description = ["Side mission Accomplished!","The hostage has been liberated!"];
 	};
 };
-["TaskSucceeded", _description] call bis_fnc_showNotification;
+["task" + "SUCCEEDED" + "Icon",[[[str(_this)] call BIS_fnc_taskType] call bis_fnc_taskTypeIcon, _description select 1]] call bis_fnc_showNotification;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/set_done.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/set_done.sqf
@@ -1,115 +1,57 @@
-if (isDedicated) exitWith {};
+
+if (isServer) exitWith {
+	[str(_this), "SUCCEEDED",false] spawn BIS_fnc_taskSetState;
+	if (_this isEqualTo 1) then {[2] spawn btc_fnc_task_create};
+};
+
+private ["_description"];
 
 switch _this do
 {
 	case 0 : {
-		private "_task";
-		_task = player getVariable ("task_0" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Misison accomplished!","Oplitas has been finally defeated!    Misison accomplished!"]] call bis_fnc_showNotification;
-
-		_task = player getVariable ("task_2" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
+		_description = ["Misison accomplished!","Oplitas has been finally defeated!    Misison accomplished!"];
 	};
 	case 1 : {
-		private "_task";
-		_task = player getVariable ("task_1" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Misison accomplished!","All the hideouts have been destroyed!"]] call bis_fnc_showNotification;
-
-		sleep 1;
-
-		[player,["task_2"],["Seize the last positions held by the enemies","Size the last enemies positions","Seize the last enemies positions"],objNull,true,1,true,"move",true] call BIS_fnc_taskCreate;
+		_description = ["Misison accomplished!","All the hideouts have been destroyed!"];
 	};
 	case 3 : {
-		private "_task";
-		_task = player getVariable ("task_3" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","Supplies have been delivered"]] call bis_fnc_showNotification;
-		player setVariable ["task_3" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","Supplies have been delivered"];
 	};
 	case 4 : {
-		private "_task";
-		_task = player getVariable ("task_4" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The minefield has been cleared"]] call bis_fnc_showNotification;
-		player setVariable ["task_4" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The minefield has been cleared"];
 	};
 	case 5 : {
-		private "_task";
-		_task = player getVariable ("task_5" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The vehicle has been repaired"]] call bis_fnc_showNotification;
-		player setVariable ["task_5" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The vehicle has been repaired"];
 	};
 	case 6 : {
-		private "_task";
-		_task = player getVariable ("task_6" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The city has been cleared!"]] call bis_fnc_showNotification;
-		player setVariable ["task_6" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The city has been cleared!"];
 	};
 	case 7 : {
-		private "_task";
-		_task = player getVariable ("task_7" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The tower has been destroyed!"]] call bis_fnc_showNotification;
-		player setVariable ["task_7" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The tower has been destroyed!"];
 	};
 	case 8 : {
-		private "_task";
-		_task = player getVariable ("task_8" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The civilian has been stabilized!"]] call bis_fnc_showNotification;
-		player setVariable ["task_8" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The civilian has been stabilized!"];
 	};
 	case 9 : {
-		private "_task";
-		_task = player getVariable ("task_9" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","Checkpoints have been destroyed!"]] call bis_fnc_showNotification;
-		player setVariable ["task_9" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","Checkpoints have been destroyed!"];
 	};
 	case 10 : {
-		private "_task";
-		_task = player getVariable ("task_10" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The civilian has been stabilized!"]] call bis_fnc_showNotification;
-		player setVariable ["task_10" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The civilian has been stabilized!"];
 	};
 	case 11 : {
-		private "_task";
-		_task = player getVariable ("task_11" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The underwater generator has been destroyed!"]] call bis_fnc_showNotification;
-		player setVariable ["task_11" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The underwater generator has been destroyed!"];
 	};
 	case 12 : {
-		private "_task";
-		_task = player getVariable ("task_12" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The armed convoy has been destroyed!"]] call bis_fnc_showNotification;
-		player setVariable ["task_12" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The armed convoy has been destroyed!"];
 	};
 	case 13 : {
-		private "_task";
-		_task = player getVariable ("task_13" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The pilot has been rescued!"]] call bis_fnc_showNotification;
-		player setVariable ["task_13" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The pilot has been rescued!"];
 	};
 	case 14 : {
-		private "_task";
-		_task = player getVariable ("task_14" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The officer has been captured!"]] call bis_fnc_showNotification;
-		player setVariable ["task_14" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The officer has been captured!"];
 	};
 	case 15 : {
-		private "_task";
-		_task = player getVariable ("task_15" call bis_fnc_taskVar);
-		_task setTaskState "SUCCEEDED";
-		["TaskSucceeded",["Side mission Accomplished!","The hostage has been liberated!"]] call bis_fnc_showNotification;
-		player setVariable ["task_15" call bis_fnc_taskVar,nil];
+		_description = ["Side mission Accomplished!","The hostage has been liberated!"];
 	};
 };
+["TaskSucceeded", _description] call bis_fnc_showNotification;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_player.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_player.sqf
@@ -18,25 +18,12 @@
 
 	call btc_fnc_int_add_actions;
 
-	//Side
-	if (btc_side_assigned) then	{
-		[] spawn {
-			btc_int_ask_data = nil;
-
-			[[5,nil,player],"btc_fnc_int_ask_var",false] spawn BIS_fnc_MP;
-
-			waitUntil {!(isNil "btc_int_ask_data")};
-
-			btc_int_ask_data spawn btc_fnc_task_create;
-		};
-	};
-
 	if (player getVariable ["interpreter", false]) then {player createDiarySubject ["Diary log","Diary log"];};
 
 	removeAllWeapons player;
 
 	waitUntil {scriptDone btc_intro_done};
-	{[_x] spawn btc_fnc_task_create} foreach [0,1];
+	{[_x] call btc_fnc_task_create} foreach (player call BIS_fnc_tasksUnit);
 };
 
 if (btc_debug) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_player.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_player.sqf
@@ -23,7 +23,7 @@
 	removeAllWeapons player;
 
 	waitUntil {scriptDone btc_intro_done};
-	{[_x] call btc_fnc_task_create} foreach (player call BIS_fnc_tasksUnit);
+	{[_x] call btc_fnc_task_create} foreach ((player call BIS_fnc_tasksUnit) select {[_x] call BIS_fnc_taskState isEqualTo "ASSIGNED"});
 };
 
 if (btc_debug) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -1,5 +1,7 @@
 call compile preprocessFile "core\fnc\city\init.sqf";
 
+{[_x] spawn btc_fnc_task_create} foreach [0,1];
+
 if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db",worldName],false]}) then {
 	if (btc_version isEqualTo (profileNamespace getVariable [format ["btc_hm_%1_version",worldName],1.13])) then	{
 		call compile preprocessFile "core\fnc\db\load.sqf";


### PR DESCRIPTION
FIX: Task notification appear to everybody when a player is connecting.

when a player is connecting, a notification to all player appear.
all task are not succeded in end mission state.
`btc_fnc_task_create/set_done/fail` are simpler know.

Final test :
- [x] local
- [x] server