### PR TITLE
Add: Optimize trigger detection

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -52,6 +52,7 @@ _p_rep = (paramsArray select 35);
 ace_rearm_level = (paramsArray select 36);
 btc_p_sea  = if ((paramsArray select 37) isEqualTo 0) then {false} else {true};
 _p_city_radius = (paramsArray select 38) * 100;
+btc_p_trigger = if (true) then {"this && !btc_db_is_saving && (false in (thisList apply {_x isKindOf 'Plane'})) && (false in (thisList apply {(_x isKindOf 'Helicopter') && (speed _x > 190)}))"} else {"this && !btc_db_is_saving"};
 btc_p_debug  = (paramsArray select 39);
 
 //MED

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -52,7 +52,7 @@ _p_rep = (paramsArray select 35);
 ace_rearm_level = (paramsArray select 36);
 btc_p_sea  = if ((paramsArray select 37) isEqualTo 0) then {false} else {true};
 _p_city_radius = (paramsArray select 38) * 100;
-btc_p_trigger = if (true) then {"this && !btc_db_is_saving && (false in (thisList apply {_x isKindOf 'Plane'})) && (false in (thisList apply {(_x isKindOf 'Helicopter') && (speed _x > 190)}))"} else {"this && !btc_db_is_saving"};
+btc_p_trigger = if (false) then {"this && !btc_db_is_saving && (false in (thisList apply {_x isKindOf 'Plane'})) && (false in (thisList apply {(_x isKindOf 'Helicopter') && (speed _x > 190)}))"} else {"this && !btc_db_is_saving"};
 btc_p_debug  = (paramsArray select 39);
 
 //MED

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_player_side.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_player_side.sqf
@@ -13,7 +13,7 @@ _id			= _this select 7;
 _trigger = createTrigger["EmptyDetector",_position];
 _trigger setTriggerArea[(_radius_x+_radius_y) + btc_city_radius,(_radius_x+_radius_y) + btc_city_radius,0,false];
 _trigger setTriggerActivation[str(btc_player_side),"PRESENT",true];
-_trigger setTriggerStatements ["this && !btc_db_is_saving", format ["[%1] spawn btc_fnc_city_activate",_id], format ["[%1] spawn btc_fnc_city_de_activate",_id]];
+_trigger setTriggerStatements [btc_p_trigger, format ["[%1] spawn btc_fnc_city_activate",_id], format ["[%1] spawn btc_fnc_city_de_activate",_id]];
 _city setVariable ["trigger_player_side",_trigger];
 
 if (btc_debug) then	{//_debug


### PR DESCRIPTION
https://forums.bistudio.com/topic/165948-mp-btc-hearts-and-minds/?do=findComment&comment=3153926

In case of slow computer/server:
It is NOT a good idea to disable spawn for Helicopter because city will
not be activate until player get out. The AI will spawn directly infront
of players ...

A clever way could be to activate city when the pilot start to decrease
the helicopter speed for landing. So during the travel, no AI will spawn
until you start to apporch your landing zone.

- [x] diable by default

Final test :
- [x] local
- [x] server