### PR TITLE
FIX: logistics point can't detect werck when FRIES is equipped on helicopters

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/repair_wreck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/repair_wreck.sqf
@@ -2,7 +2,7 @@
 private ["_object","_array"];
 
 _object = _this select 0;
-_array = nearestObjects [position _object, ["LandVehicle","Air"], 10];
+_array = (nearestObjects [position _object, ["LandVehicle","Air"], 10]) select {!((_x isKindOf "ACE_friesGantry") OR (typeof _x isEqualTo "ACE_friesAnchorBar"))};
 
 if (count _array == 0) exitWith {hint "No wreck";};
 


### PR DESCRIPTION
FIX: logistics point can't detect wreck when FRIES is equipped on helicopters.

https://github.com/Vdauphin/HeartsAndMinds/issues/305

Final test :
- [x] local
- [x] server
