### PR TITLE
ADD: a reputation change whenever a building is destroyed

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -159,6 +159,35 @@ if (isServer) then {
 	//Vehs
 	btc_vehicles = [btc_veh_1,btc_veh_2,btc_veh_3,btc_veh_4,btc_veh_5,btc_veh_6,btc_veh_7,btc_veh_8,btc_veh_9,btc_veh_10,btc_veh_11,btc_veh_12,btc_veh_13,btc_veh_14,btc_veh_15];
 	btc_helo = [btc_helo_1];
+
+	// The two arrays below are prefixes of buildings and their multiplier.
+	// They will multiply the values of btc_rep_malus_building_destroyed and btc_rep_malus_building_damaged,
+	// if a building is not present here it will be multiplied by 1.0.
+	// Use 0.0 to disable reputation hit on a specific's building destruction.
+	// You can modify this for any other terrain, clearing the table will also make all buildings just have a 1.0 multiplier.
+	// If there's a hit in btc_buildings_multiplier, btc_buildings_categories_multipliers will NOT be run
+	btc_buildings_multipliers = [
+	// Specific buildings that need to have a custom modifier.
+	["Land_BellTower", 0.2 ], ["Land_WIP", 1.5], ["Land_u_Addon_01", 0.2], 
+	["Land_Airport_Tower", 10.0], ["Land_Mil_ControlTower", 10.0],
+	["Land_TentHangar", 7.0], ["Land_i_Shed_Ind", 1.5], ["Land_u_Shed_Ind", 1.5],
+	["Land_TTowerBig", 6.0], ["Land_TTowerSmall", 4.5], ["Land_cmp_Tower", 4.0]
+	];
+
+	// The multipliers are applied on top of each other, so "Chapel" and "Small" will both multiply the malus value
+	btc_buildings_categories_multipliers = [
+	["Shed", 0.75], ["Slum", 0.8], ["Small", 0.8], ["Big", 1.5], ["Villa", 2.0], ["Main", 3.0], ["Tower", 2.0],
+	["HouseBlock", 2.0], ["Panelak", 2.0], ["Tenement", 7.0],
+	["Barn", 1.5], ["School", 3.0], ["Office", 2.0], ["Shop", 1.5], ["Store", 1.5], ["Hospital", 12.0],
+	["Castle", 2.5], ["Chapel", 3.0], ["Minaret", 3.0], ["Mosque", 4.0], ["Church", 4.0], ["Kostel", 4.0],
+	["Lighthouse", 4.0],
+	["Airport", 4.0], ["Hangar", 1.75], ["ControlTower", 2.25], ["Terminal", 3.0],
+	["Hopper", 2.0], ["Tank", 4.0], ["Factory", 2.0], ["Transformer", 1.1],
+	["FuelStation", 5.0],
+	["Barracks", 1.75],
+	["spp", 3.0], ["Powerstation", 3.0],
+	["Pump", 2.5]
+	];
 };
 
 //City
@@ -521,6 +550,8 @@ btc_rep_malus_civ_killed = - 10;
 btc_rep_malus_civ_firenear = - 5;
 btc_rep_malus_player_respawn = - 10;
 btc_rep_malus_veh_killed = - 25;
+btc_rep_malus_building_damaged = - 2.5;
+btc_rep_malus_building_destroyed = - 5;
 
 //Side
 if (isNil "btc_side_assigned") then {btc_side_assigned = false;};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/doc.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/doc.sqf
@@ -114,7 +114,7 @@ When you destroy an hideout or an ammo cache, all the markers related to it will
 player createDiaryRecord ["Documentation", ["Reputation", "
 <img image='\A3\ui_f\data\igui\cfg\simpleTasks\types\talk_ca.paa' width='20' height='20'/> Reputation can be ask to civilian<br/>
 Bad actions cause bad effetcs.<br/>
-<img image='\A3\ui_f\data\igui\cfg\simpleTasks\types\meet_ca.paa' width='20' height='20'/> Helping the local population, fighting the Oplitas, disarming IED will rise your reputation; killing civilians, firing near civilians for no reason, losing vehicles, respawns will decrease your repution. At the beginning you have a very low reputation level, so civilians won't help you revealing important information about Oplitas, they will likely lie instead.
+<img image='\A3\ui_f\data\igui\cfg\simpleTasks\types\meet_ca.paa' width='20' height='20'/> Helping the local population, fighting the Oplitas, disarming IED will rise your reputation; killing civilians, firing near civilians for no reason, damaging/destroying buildings, losing vehicles, respawns will decrease your repution. At the beginning you have a very low reputation level, so civilians won't help you revealing important information about Oplitas, they will likely lie instead.
 	"]
 ];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -64,6 +64,7 @@ if (isServer) then {
 	btc_fnc_eh_veh_respawn = compile preprocessFile "core\fnc\eh\veh_respawn.sqf";
 	btc_fnc_eh_explosives_defuse = compile preprocessFile "core\fnc\eh\explosives_defuse.sqf";
 	btc_fnc_eh_handledisconnect = compile preprocessFile "core\fnc\eh\handledisconnect.sqf";
+	btc_fnc_eh_buildingchanged = compile preprocessFile "core\fnc\eh\buildingchanged.sqf";
 
 	//IED
 	btc_fnc_ied_boom = compile preprocessFile "core\fnc\ied\boom.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/buildingchanged.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/buildingchanged.sqf
@@ -1,0 +1,29 @@
+params ["_from", "_to", "_isRuin"];
+private _classname = toUpper typeOf _from;
+private _malus = [btc_rep_malus_building_damaged, btc_rep_malus_building_destroyed] select _isRuin;
+private _skipCategories = false;
+
+// Accept only static, terrain buildings, discard any dynamically created ones
+if (getObjectType _from != 1) exitWith { };
+
+{
+	if (_classname find (toUpper (_x select 0)) != -1) exitWith {
+		_malus = _malus * (_x select 1);
+		_skipCategories = true;
+	};
+} forEach btc_buildings_multipliers;
+
+if (!_skipCategories) then {
+	{
+		if (_classname find (toUpper (_x select 0)) != -1) then {
+			_malus = _malus * (_x select 1);
+		};
+	} forEach btc_buildings_categories_multipliers;
+};
+
+if (btc_debug) then {
+	systemChat format [ "BuildingChanged: %1 to %2. Malus: %3",
+	typeOf _from, typeOf _to, _malus ];
+};
+
+_malus call btc_fnc_rep_change;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -24,6 +24,8 @@ call btc_fnc_db_autosave;
 
 addMissionEventHandler ["HandleDisconnect",btc_fnc_eh_handledisconnect];
 
+addMissionEventHandler ["BuildingChanged",btc_fnc_eh_buildingchanged];
+
 ["ace_explosives_defuse", btc_fnc_eh_explosives_defuse] call CBA_fnc_addEventHandler;
 
 ["Initialize"] call BIS_fnc_dynamicGroups;


### PR DESCRIPTION
- Add: Reputation malus when a building is damaged/destroyed (https://github.com/Vdauphin/HeartsAndMinds/pull/349).

Links to #288 

I don't have a dedicated server yet to test it on properly, but I'm looking mainly for review comments (although if someone can test it I won't say no to that!). As you can see in the code the idea is that the reputation malus can be applied in two ways: either by damaging a building or destroying. Technically destroying a building outright is better for your reputation then damaging and destroying, but in a way it makes sense - people don't really like you breaking their houses and then finishing them up later. ;)

The filter is applied on a prefix basis, so the first entry that matches the prefix will be the multiplier we take. I've set up basic multipliers to weed out: small buildings that shouldn't be that big of an issue, larger buildings that get a 1.5-2.0 multiplier. Chapels (churches are invincible apparently?) that go from 2.5 and 3.0, and then industrial/transport/communication buildings which give a massive penalty. After all no-one likes their factories getting ripped to shreds. Please check if you're fine with the numbers!

I looked through the code provided by @Breech99 but I don't think that's needed at the moment, as in we are only interested in knowing whether there's some building somewhere that transitions from one phase to another, the netids might come in useful though in the future to store the states of buildings between saves.


Final test :
- [x] local
- [x] server