### PR TITLE
FIX: Rep malus not apply for building already damaged by player

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -190,6 +190,7 @@ if (isServer) then {
 	["spp", 3.0], ["Powerstation", 3.0],
 	["Pump", 2.5]
 	];
+	btc_buildings_changed = [];
 };
 
 //Civ

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/buildingchanged.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/buildingchanged.sqf
@@ -4,7 +4,7 @@ private _malus = [btc_rep_malus_building_damaged, btc_rep_malus_building_destroy
 private _skipCategories = false;
 
 // Accept only static, terrain buildings, discard any dynamically created ones but keep already damaged buildings.
-if ((getObjectType _from != 1) && !(_from in btc_buildings_changed)) exitWith {systemChat "buildings ingnore"};
+if ((getObjectType _from != 1) && !(_from in btc_buildings_changed)) exitWith {};
 
 btc_buildings_changed pushBack _to;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/buildingchanged.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/buildingchanged.sqf
@@ -3,8 +3,10 @@ private _classname = toUpper typeOf _from;
 private _malus = [btc_rep_malus_building_damaged, btc_rep_malus_building_destroyed] select _isRuin;
 private _skipCategories = false;
 
-// Accept only static, terrain buildings, discard any dynamically created ones
-if (getObjectType _from != 1) exitWith { };
+// Accept only static, terrain buildings, discard any dynamically created ones but keep already damaged buildings.
+if ((getObjectType _from != 1) && !(_from in btc_buildings_changed)) exitWith {systemChat "buildings ingnore"};
+
+btc_buildings_changed pushBack _to;
 
 {
 	if (_classname find (toUpper (_x select 0)) != -1) exitWith {


### PR DESCRIPTION
https://github.com/Vdauphin/HeartsAndMinds/pull/349

@mtusnio When a building is damaged by player the building become a dynamic
 (not a 1 - Primary but a 8 - TypeVehicle see here : https://community.bistudio.com/wiki/getObjectType). 
Before the filter discard those buildings.
Now player receive malus for building already damaged by player.

Final test :
- [x] local
- [x] server
