### PR TITLE
FIX: Vehicle explosion damage other objects around during database loading

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -257,7 +257,7 @@ diag_log format ["5: %1",(_x select 5)];
 		_veh setVariable ["ace_cookoff_enable", false];
 		_veh setVariable ["ace_cookoff_enableAmmoCookoff", false];
 		{
-			[_veh, _foreachindex, _x] call ace_repair_fnc_setHitPointDamage;
+			[_veh, _foreachindex, _x, false] call ace_repair_fnc_setHitPointDamage;
 		} forEach ((_x select 4) select 2);
 		_veh setVariable ["ace_cookoff_enable", nil];
 		_veh setVariable ["ace_cookoff_enableAmmoCookoff", nil];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -254,16 +254,14 @@ diag_log format ["5: %1",(_x select 5)];
 		};
 
 		//Disable explosion effect during database loading
-		_veh setVariable ["ace_cookoff_enable", false];
-		_veh setVariable ["ace_cookoff_enableAmmoCookoff", false];
 		{
 			[_veh, _foreachindex, _x, false] call ace_repair_fnc_setHitPointDamage;
 		} forEach ((_x select 4) select 2);
 		if (((_x select 4) select 2) select {_x < 1} isEqualTo []) then {
+			_veh setVariable ["ace_cookoff_enable", false, true];
+			_veh setVariable ["ace_cookoff_enableAmmoCookoff", false, true];
 			_veh setDamage [1, false];
 		};
-		_veh setVariable ["ace_cookoff_enable", nil];
-		_veh setVariable ["ace_cookoff_enableAmmoCookoff", nil];
 	} foreach _vehs;
 }, _vehs, 0.5] call CBA_fnc_waitAndExecute;
 


### PR DESCRIPTION
- FIX: Vehicle explosion damage other objects around during database loading.

https://github.com/Vdauphin/HeartsAndMinds/pull/374

Need : ACE 3.11, https://github.com/acemod/ACE3/pull/5318

Final test :
- [x] local
- [x] server