### PR TITLE
FIX: Anti-Air infantry filter

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/class.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/class.sqf
@@ -59,7 +59,21 @@ if (_enemy_side isEqualTo btc_player_side) exitWith {
 //Final filter unwanted units type
 if !(_en_AA) then {
 	//Remove Anti-Air Units
-	_type_units		= _type_units select {((_x find "AAA_") isEqualTo -1) && ((_x find "_AA_") isEqualTo -1)};
+	_type_units		= _type_units select {
+		private _unit = _x;
+		private _weapons = getarray(configfile >> "CfgVehicles" >> _unit >> "weapons");
+
+		_isAA = _weapons apply {
+			private _weapon = _x;
+			private _magazines = getarray(configfile >> "CfgWeapons" >> _weapon >> "magazines");
+			private _ammo = "";
+			if !(_magazines isEqualTo []) then 	{
+				_ammo =	gettext(configfile >> "CfgMagazines" >> _magazines select 0 >> "ammo");
+			};
+			(getnumber(configfile >> "CfgAmmo" >> _ammo >> "aiAmmoUsageFlags") isEqualTo 256);
+		};
+		!(true in _isAA)
+	};
 };
 _type_units		= _type_units select {((_x find "pilot_") isEqualTo -1) && ((_x find "_Pilot_") isEqualTo -1) && ((_x find "_Survivor_") isEqualTo -1) && ((_x find "_Story") isEqualTo -1) && ((_x find "_base") isEqualTo -1) && ((_x find "_unarmed_") isEqualTo -1) && ((_x find "_VR_") isEqualTo -1)};
 _type_crewmen	= _type_units select 0;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/class.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/class.sqf
@@ -63,7 +63,7 @@ if !(_en_AA) then {
 		private _unit = _x;
 		private _weapons = getarray(configfile >> "CfgVehicles" >> _unit >> "weapons");
 
-		_isAA = _weapons apply {
+		private _isAA = _weapons apply {
 			private _weapon = _x;
 			private _magazines = getarray(configfile >> "CfgWeapons" >> _weapon >> "magazines");
 			private _ammo = "";
@@ -72,6 +72,7 @@ if !(_en_AA) then {
 			};
 			(getnumber(configfile >> "CfgAmmo" >> _ammo >> "aiAmmoUsageFlags") isEqualTo 256);
 		};
+		if (btc_debug_log) then {diag_log format ["btc_fnc_mil_class %1 Weapons: %2 isAA: %3", _unit, _weapons , _isAA];};
 		!(true in _isAA)
 	};
 };


### PR DESCRIPTION
fix : https://forums.bistudio.com/forums/topic/165948-mp-btc-hearts-and-minds/?page=32&tab=comments#comment-3239466

https://community.bistudio.com/wiki/CfgAmmo_Config_Reference#aiAmmoUsageFlags

thanks @PabstMirror and @baermitumlaut

Final test :
- [x] local
- [x] server

this allow the detection of multiple aiAmmoUsageFlags like `"64 + 128 + 256"`
```
private _input = getnumber(configfile >> "CfgAmmo" >> _ammo >> "aiAmmoUsageFlags");
private _binString = [_input, 9] call ace_common_fnc_toBin;
private _bit256Set = (_binString select [(count _binString) - 9, 1]) == "1";
diag_log format ["BTC unit %1 ammo %2 input %3 %4", _unit,_ammo, _input,_bit256Set];
_bit256Set
```
This is not suitable because many weapons have 256 number. Anti Air weapons have only 256 number.