### PR TITLE
FIX: Sidemission: destroy underwater generator Script error

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/underwater_generator.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/underwater_generator.sqf
@@ -58,7 +58,7 @@ _group = [_pos,8, 1 + round random 5,0.8] call btc_fnc_mil_create_group;
 [_pos,20, 2 + round random 4,0.5] call btc_fnc_mil_create_group;
 
 _pos = getPosASL _generator;
-leader _group setPosASL [_pos select 0, _pos select 1, (_pos select 2) + 1 + random 1];
+(leader (_group select 0)) setPosASL [_pos select 0, _pos select 1, (_pos select 2) + 1 + random 1];
 
 waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || !Alive _generator )};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/description.ext
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/description.ext
@@ -33,5 +33,3 @@ class RscTitles {
 #include "core\def\functions.hpp"
 
 #include "core\fnc\eh\extended_InitPost_EH.hpp"
-
-enableDebugConsole = 1;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/description.ext
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/description.ext
@@ -33,3 +33,5 @@ class RscTitles {
 #include "core\def\functions.hpp"
 
 #include "core\fnc\eh\extended_InitPost_EH.hpp"
+
+enableDebugConsole = 1;


### PR DESCRIPTION
**When merged this pull request will:**
- fix a small script error in 'core/fnc/side/underwater_generator.sqf' (since https://github.com/Vdauphin/HeartsAndMinds/pull/383)


**Final test:**
- [x] local
- [x] server

**excerpt from the RPT log**
```
14:42:31 Error in expression <te_group;

_pos = getPosASL _generator;
leader _group setPosASL [_pos select 0, >
14:42:31   Error position: <leader _group setPosASL [_pos select 0, >
14:42:31   Error leader: Typ Array, erwartet Objekt,Gruppe,Team member
14:42:31 File E:\Dokumente\Arma 3\mpmissions\ArmA-OtherProjects\HeartsAndMinds\=BTC=co@30_Hearts_and_Minds.Altis\core\fnc\side\underwater_generator.sqf, line 61
``` 
