### PR TITLE
FIX: deploy FOB hint, missing space

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/show_hint.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/show_hint.sqf
@@ -27,7 +27,7 @@ switch (_type) do {
 		hint (localize "STR_BTC_HAM_O_COMMON_SHOWHINTS_6"); //In the last hideout we found important intel about all the cities occupied by the Oplitas! Size the last positions held by the enemies and defeat them once and for all
 	};
 	case 7 : {
-		hint ((_this select 1) + (localize "STR_BTC_HAM_O_COMMON_SHOWHINTS_7")); // has been deployed!
+		hint format [(localize "STR_BTC_HAM_O_COMMON_SHOWHINTS_7"),(_this select 1)]; // has been deployed!
 	};
 	case 8 : {
 		hint (localize "STR_BTC_HAM_O_COMMON_SHOWHINTS_8"); //Saving in progress...Please wait

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -1474,9 +1474,9 @@
                 <German>In the last hideout we found important intel about all the cities occupied by the Oplitas! Size the last positions held by the enemies and defeat them once and for all</German>
             </Key>
             <Key ID="STR_BTC_HAM_O_COMMON_SHOWHINTS_7">
-                <Original> has been deployed!</Original>
-                <English> has been deployed!</English>
-                <German> wurde bereitgestellt!</German>
+                <Original>%1 has been deployed!</Original>
+                <English>%1 has been deployed!</English>
+                <German>%1 wurde bereitgestellt!</German>
             </Key>
             <Key ID="STR_BTC_HAM_O_COMMON_SHOWHINTS_8">
                 <Original>Saving in progress...Please wait</Original>


### PR DESCRIPTION
**When merged this pull request will:**
- fixed a small spacing error in the hint, when a FOB is created (see screenshots below)
- replaced `+` with `format` in /core/fnc/common/show_hint.sqf
- a small adjustment in stringtable.xml

**Final test:**
- [x] local
- [x] server


**Screenshots**
OLD:
![fob_created_hint](https://user-images.githubusercontent.com/19553317/33259029-c7a412f0-d35b-11e7-8e89-f7dd8dd328ea.jpg)

NEW:
![fob_created_hint_new](https://user-images.githubusercontent.com/19553317/33259039-d1af7a50-d35b-11e7-880f-956f0f2702fa.jpg)
