### PR TITLE
FIX: Missing basic value in rearm (param.hpp)

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -259,7 +259,7 @@ class Params {
 	};
 	class btc_p_rearm { // Rearm Level:
 		title = __EVAL(format ["      %1",(localize "STR_BTC_HAM_PARAM_OTHER_REARMLEVEL")]);
-		values[]={0,1,2};
+		values[]={-1,0,1,2};
 		texts[]={$STR_BTC_HAM_O_BASIC_DEFAULT,$STR_ACE_Rearm_RearmSettings_vehicle,$STR_ACE_Rearm_RearmSettings_magazine,$STR_ACE_Rearm_RearmSettings_caliber}; // texts[]={"Default","Entire Vehicle","Entire Magazine","Amount based on caliber"};
 		default = -1;
 	};


### PR DESCRIPTION
**When merged this pull request will:**
- only a missing selection was added
- caused by #419 ([/core/def/param.hpp](https://github.com/Vdauphin/HeartsAndMinds/pull/419/files#diff-259f057b3d896120baeaa5846a6b013dL262))

**Final test:**
- [x] local
- [x] server
