### PR TITLE
FIX: Enemy spawn inside rock

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/findposoutsiderock.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/findposoutsiderock.sqf
@@ -1,13 +1,12 @@
 
 params ["_rpos"];
 
-private _rposASL = [_rpos select 0, _rpos select 1, getTerrainHeightASL _rpos];
-private _objects = lineIntersectsObjs [[_rposASL select 0, _rposASL select 1, (_rposASL select 2) + 1], [_rposASL select 0, _rposASL select 1, (_rposASL select 2) + 100], objNull, objNull, false, 16];
+private _objects = lineIntersectsObjs [[_rpos select 0, _rpos select 1, (getTerrainHeightASL _rpos) + 1], [_rpos select 0, _rpos select 1, (getTerrainHeightASL _rpos) + 100], objNull, objNull, false, 16];
 
 if (_objects isEqualTo []) exitWith {_rpos};
 
 private _object = _objects select 0;
-if (_object in nearestTerrainObjects [_object, ["Rock"], 1]) then {
+if (_object in nearestTerrainObjects [_object, ["HIDE", "ROCK", "ROCKS"], 1]) then {
 	_roads = _rpos nearRoads 100;
 	if (_roads isEqualTo []) then {
 		_rpos = [_rpos,5,50,10,false] call btc_fnc_findsafepos;
@@ -17,11 +16,10 @@ if (_object in nearestTerrainObjects [_object, ["Rock"], 1]) then {
 };
 
 if (btc_debug_log) then {
-	_rposASL = [_rpos select 0, _rpos select 1, getTerrainHeightASL _rpos];
-	_objects = lineIntersectsObjs [[_rposASL select 0, _rposASL select 1, (_rposASL select 2) + 1], [_rposASL select 0, _rposASL select 1, (_rposASL select 2) + 100], objNull, objNull, false, 16];
+	_objects = lineIntersectsObjs [[_rpos select 0, _rpos select 1, (getTerrainHeightASL _rpos) + 1], [_rpos select 0, _rpos select 1, (getTerrainHeightASL _rpos) + 100], objNull, objNull, false, 16];
 	if !(_objects isEqualTo []) then {
 		_object = _objects select 0;
-		if (_object in nearestTerrainObjects [_object, ["Rock"], 1]) then {
+		if (_object in nearestTerrainObjects [_object, ["HIDE", "ROCK", "ROCKS"], 1]) then {
 			diag_log format ["FIND POS OUTSIDE ROCK: POS %1 Still inside rock", _rposASL];
 			if (btc_debug) then {
 				systemChat "FIND POS OUTSIDE ROCK: Still inside rock";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/findposoutsiderock.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/findposoutsiderock.sqf
@@ -1,0 +1,34 @@
+
+params ["_rpos"];
+
+private _rposASL = [_rpos select 0, _rpos select 1, getTerrainHeightASL _rpos];
+
+private _objects = lineIntersectsObjs [[_rposASL select 0 , _rposASL select 1 , (_rposASL select 2) + 1], [_rposASL select 0 , _rposASL select 1 , (_rposASL select 2) + 100],objNull,objNull,false,16];
+
+if (_objects isEqualTo []) exitWith {_rpos};
+
+private _object = _objects select 0;
+
+if (_object in nearestTerrainObjects [_object, ["Rock"], 1]) then {
+
+	_roads = _rpos nearRoads 100;
+	if (_roads isEqualTo []) then {
+		_rpos = [_rpos,5,50,10,false] call btc_fnc_findsafepos;
+	} else {
+		_rpos = getPos (_roads select 0);
+	};
+};
+
+if (btc_debug) then {
+	private _objects = lineIntersectsObjs [[_rposASL select 0 , _rposASL select 1 , (_rposASL select 2) + 1], [_rposASL select 0 , _rposASL select 1 , (_rposASL select 2) + 100],objNull,objNull,false,16];
+	private _object = _objects select 0;
+	if (_object in nearestTerrainObjects [_object, ["Rock"], 1]) then {
+			systemChat "FIND POS OUTSIDE ROCK: Still inside rock";
+			createmarker [format ["btc_inrock_%1", _rpos], _rpos];
+			format ["btc_inrock_%1", _rpos] setmarkertype "mil_unknown";
+			format ["btc_inrock_%1", _rpos] setMarkerText "In rock";
+			format ["btc_inrock_%1", _rpos] setMarkerSize [0.5, 0.5];
+	};
+};
+
+_rpos

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/findposoutsiderock.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/findposoutsiderock.sqf
@@ -2,15 +2,12 @@
 params ["_rpos"];
 
 private _rposASL = [_rpos select 0, _rpos select 1, getTerrainHeightASL _rpos];
-
-private _objects = lineIntersectsObjs [[_rposASL select 0 , _rposASL select 1 , (_rposASL select 2) + 1], [_rposASL select 0 , _rposASL select 1 , (_rposASL select 2) + 100],objNull,objNull,false,16];
+private _objects = lineIntersectsObjs [[_rposASL select 0, _rposASL select 1, (_rposASL select 2) + 1], [_rposASL select 0, _rposASL select 1, (_rposASL select 2) + 100], objNull, objNull, false, 16];
 
 if (_objects isEqualTo []) exitWith {_rpos};
 
 private _object = _objects select 0;
-
 if (_object in nearestTerrainObjects [_object, ["Rock"], 1]) then {
-
 	_roads = _rpos nearRoads 100;
 	if (_roads isEqualTo []) then {
 		_rpos = [_rpos,5,50,10,false] call btc_fnc_findsafepos;
@@ -19,15 +16,21 @@ if (_object in nearestTerrainObjects [_object, ["Rock"], 1]) then {
 	};
 };
 
-if (btc_debug) then {
-	private _objects = lineIntersectsObjs [[_rposASL select 0 , _rposASL select 1 , (_rposASL select 2) + 1], [_rposASL select 0 , _rposASL select 1 , (_rposASL select 2) + 100],objNull,objNull,false,16];
-	private _object = _objects select 0;
-	if (_object in nearestTerrainObjects [_object, ["Rock"], 1]) then {
-			systemChat "FIND POS OUTSIDE ROCK: Still inside rock";
-			createmarker [format ["btc_inrock_%1", _rpos], _rpos];
-			format ["btc_inrock_%1", _rpos] setmarkertype "mil_unknown";
-			format ["btc_inrock_%1", _rpos] setMarkerText "In rock";
-			format ["btc_inrock_%1", _rpos] setMarkerSize [0.5, 0.5];
+if (btc_debug_log) then {
+	_rposASL = [_rpos select 0, _rpos select 1, getTerrainHeightASL _rpos];
+	_objects = lineIntersectsObjs [[_rposASL select 0, _rposASL select 1, (_rposASL select 2) + 1], [_rposASL select 0, _rposASL select 1, (_rposASL select 2) + 100], objNull, objNull, false, 16];
+	if !(_objects isEqualTo []) then {
+		_object = _objects select 0;
+		if (_object in nearestTerrainObjects [_object, ["Rock"], 1]) then {
+			diag_log format ["FIND POS OUTSIDE ROCK: POS %1 Still inside rock", _rposASL];
+			if (btc_debug) then {
+				systemChat "FIND POS OUTSIDE ROCK: Still inside rock";
+				private _marker = createmarker [format ["btc_inrock_%1", _rpos], _rpos];
+				_marker setmarkertype "mil_unknown";
+				_marker setMarkerText "In rock";
+				_marker setMarkerSize [0.5, 0.5];
+			};
+		};
 	};
 };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/findposoutsiderock.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/findposoutsiderock.sqf
@@ -20,7 +20,7 @@ if (btc_debug_log) then {
 	if !(_objects isEqualTo []) then {
 		_object = _objects select 0;
 		if (_object in nearestTerrainObjects [_object, ["HIDE", "ROCK", "ROCKS"], 1]) then {
-			diag_log format ["FIND POS OUTSIDE ROCK: POS %1 Still inside rock", _rposASL];
+			diag_log format ["FIND POS OUTSIDE ROCK: POS %1 Still inside rock", _rpos];
 			if (btc_debug) then {
 				systemChat "FIND POS OUTSIDE ROCK: Still inside rock";
 				private _marker = createmarker [format ["btc_inrock_%1", _rpos], _rpos];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -26,6 +26,7 @@ if (isServer) then {
 	btc_fnc_find_closecity = compile preprocessFile "core\fnc\common\find_closecity.sqf";
 	btc_fnc_deletegroup = compile preprocessFile "core\fnc\common\deletegroup.sqf";
 	btc_fnc_delete = compile preprocessFile "core\fnc\common\delete.sqf";
+	btc_fnc_findPosOutsideRock = compile preprocessFile "core\fnc\common\findposoutsiderock.sqf";
 
 	//CITY
 	btc_fnc_city_activate = compile preprocessFile "core\fnc\city\activate.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_group.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_group.sqf
@@ -16,18 +16,19 @@ switch (typeName _city) do {
 
 _rpos = [_pos, _area, btc_p_sea] call btc_fnc_randomize_pos;
 
-_pos_iswater = (surfaceIsWater _rpos);
+_pos_iswater = surfaceIsWater _rpos;
 if (_pos_iswater) then {
 	_unit_type = selectRandom btc_type_divers;
 } else {
 	_unit_type = selectRandom btc_type_units;
-	_newpos = _rpos findEmptyPosition [0, 40];
+	_newpos = _rpos findEmptyPosition [0, 40, _unit_type];
 	if !(_newpos isEqualTo []) then {_rpos = _newpos;};
+	_rpos = [_rpos] call btc_fnc_findPosOutsideRock;
 };
 
 _group = createGroup btc_enemy_side;
 [_group createUnit [_unit_type, _rpos, [], 0, "NONE"]] joinSilent _group;
-(leader _group) setpos _rpos;
+(leader _group) setPos _rpos;
 _in_house = false;
 
 switch (true) do {


### PR DESCRIPTION
**When merged this pull request will:**
- check if enemy spawn inside rock by detecting the intersection of a line draw between the spawning position to the same position but with an offset of 100 meter.
- Check if the object intersecting the line is a rock.
- Search for a road or a safe poistion.

- [x] check water spawn
- [x] test on malden

**Final test:**
- [x] local
- [x] server

RTP : [Arma3_x64_2017-12-15_10-26-02.txt](https://github.com/Vdauphin/HeartsAndMinds/files/1562409/Arma3_x64_2017-12-15_10-26-02.txt)

**Screenshots**

![107410_20171215104554_1](https://user-images.githubusercontent.com/14364400/34038570-1ef69b88-e18d-11e7-9d4c-ee03354fd4ef.png)
![107410_20171215104635_1](https://user-images.githubusercontent.com/14364400/34038704-933c35a2-e18d-11e7-9501-7b74a383f4ac.png)
![107410_20171215113007_1](https://user-images.githubusercontent.com/14364400/34038573-1f327d88-e18d-11e7-8a88-7e15790b9e14.png)
![107410_20171215113402_1](https://user-images.githubusercontent.com/14364400/34038574-1f4d6210-e18d-11e7-8097-ef3d7d7d79da.png)
![107410_20171215113417_1](https://user-images.githubusercontent.com/14364400/34038575-1f68e6ca-e18d-11e7-8108-d954835dac37.png)
