### PR TITLE
FIX: Remove deprecated ACE module/mission parameters

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -67,6 +67,7 @@ btc_p_debug  = "btc_p_debug" call BIS_fnc_getParamValue;
 if (ace_medical_maxReviveTime > 0) then {ace_medical_enableRevive = 1;ace_medical_preventInstaDeath = true};
 ace_medical_enableFor = 1;
 ace_cargo_enable = false;
+ace_respawn_savePreDeathGear = true;
 
 //btc_acre_mod = isClass(configFile >> "cfgPatches" >> "acre_main");
 //btc_tfr_mod = isClass(configFile >> "cfgPatches" >> "task_force_radio");

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -30,9 +30,6 @@ _info_chance = "btc_p_info_chance" call BIS_fnc_getParamValue;
 
 //<< Medical options >>
 btc_p_redeploy = ("btc_p_redeploy" call BIS_fnc_getParamValue) isEqualTo 1;
-ace_medical_level = "btc_p_med_level" call BIS_fnc_getParamValue;
-ace_medical_enableAdvancedWounds = ("btc_p_adv_wounds" call BIS_fnc_getParamValue) isEqualTo 1;
-ace_medical_maxReviveTime = "btc_p_rev" call BIS_fnc_getParamValue;
 
 //<< Skill options >>
 btc_p_set_skill  = ("btc_p_set_skill" call BIS_fnc_getParamValue) isEqualTo 1;
@@ -57,17 +54,10 @@ btc_p_side_mission_cycle = ("btc_p_side_mission_cycle" call BIS_fnc_getParamValu
 
 //<< Other options >>
 _p_rep = "btc_p_rep" call BIS_fnc_getParamValue;
-ace_rearm_level = "btc_p_rearm" call BIS_fnc_getParamValue;
 btc_p_garage = ("btc_p_garage" call BIS_fnc_getParamValue) isEqualTo 1;
 _p_city_radius = ("btc_p_city_radius" call BIS_fnc_getParamValue) * 100;
 btc_p_trigger = if (("btc_p_trigger" call BIS_fnc_getParamValue) isEqualTo 1) then {"this && !btc_db_is_saving && (false in (thisList apply {_x isKindOf 'Plane'})) && (false in (thisList apply {(_x isKindOf 'Helicopter') && (speed _x > 190)}))"} else {"this && !btc_db_is_saving"};
 btc_p_debug  = "btc_p_debug" call BIS_fnc_getParamValue;
-
-//OPTION must be use for H&M
-if (ace_medical_maxReviveTime > 0) then {ace_medical_enableRevive = 1;ace_medical_preventInstaDeath = true};
-ace_medical_enableFor = 1;
-ace_cargo_enable = false;
-ace_respawn_savePreDeathGear = true;
 
 //btc_acre_mod = isClass(configFile >> "cfgPatches" >> "acre_main");
 //btc_tfr_mod = isClass(configFile >> "cfgPatches" >> "task_force_radio");

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -125,24 +125,6 @@ class Params {
 		texts[]={"Off","On"};
 		default = 1;
 	};
-	class btc_p_med_level {
-	   title = "			Medical Level";
-	   values[] = {1,2};
-	   texts[] = {"Basic","Advanced"};
-	   default = 1;
-	};
-	class btc_p_adv_wounds {
-	   title = "			Advanced Wounds";
-	   values[] = {0,1};
-	   texts[] = {"Off","On"};
-	   default = 1;
-	};
-	class btc_p_rev {
-		title = "			Revive time:";
-		values[]={0,60,120,180,240,300,600,900,1200,999999};
-		texts[]={"Off","60","120","180","240","300","600","900","1200","999999"};
-		default = 600;
-	};
 	class btc_p_skill_title {
 		title = "<< A3 Skill options >>";
 		values[]={0};
@@ -256,12 +238,6 @@ class Params {
 		values[]={0, 200, 500, 750};
 		texts[]={"Very Low","Low","Normal","High"};
 		default = 200;
-	};
-	class btc_p_rearm {
-		title = "			Rearm Level:";
-		values[]={0,1,2};
-		texts[]={"Entire vehicle","Entire magazine","Amount based on caliber"};
-		default = 1;
 	};
 	class btc_p_garage {
 		title = "			Activate garage for admin:";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/description.ext
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/description.ext
@@ -3,6 +3,7 @@ loadScreen = "core\img\btc.paa";
 author = Giallustio;
 onLoadName = Hearts and Minds;
 onLoadMission = www.blacktemplars.altervista.org;
+enabledebugconsole = 1;
 
 #include "core\def\dlg_def.hpp"
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/mission.sqm
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/mission.sqm
@@ -263,7 +263,7 @@ class CustomAttributes
 								};
 								class value
 								{
-									items=1;
+									items=4;
 									class Item0
 									{
 										class data
@@ -276,6 +276,48 @@ class CustomAttributes
 												};
 											};
 											value="ace_respawn_savepredeathgear";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_enablefor";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_cargo_enable";
+										};
+									};
+									class Item3
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_rearm_level";
 										};
 									};
 								};
@@ -294,7 +336,7 @@ class CustomAttributes
 								};
 								class value
 								{
-									items=1;
+									items=4;
 									class Item0
 									{
 										class data
@@ -320,7 +362,142 @@ class CustomAttributes
 																"BOOL"
 															};
 														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
 														value=0;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item3
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
 													};
 												};
 												class Item1

--- a/=BTC=co@30_Hearts_and_Minds.Altis/mission.sqm
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/mission.sqm
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={8330.0225,187.05653,10023.455};
-		dir[]={0.053734943,-0.82017767,0.5696947};
-		up[]={0.077020578,0.57209378,0.81656778};
-		aside[]={0.99564278,3.8654252e-007,-0.093911856};
+		pos[]={8297.6123,93.258369,10061.557};
+		dir[]={0.58210856,-0.81064433,0.064327784};
+		up[]={0.80575699,0.58552009,0.089042641};
+		aside[]={0.10984567,4.5113848e-007,-0.99401075};
 	};
 };
 binarizationWanted=0;
@@ -178,24 +178,6 @@ class CustomAttributes
 		name="Multiplayer";
 		class Attribute0
 		{
-			property="RespawnTemplates";
-			expression="true";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"ARRAY"
-						};
-					};
-				};
-			};
-		};
-		class Attribute1
-		{
 			property="RespawnButton";
 			expression="true";
 			class Value
@@ -210,6 +192,24 @@ class CustomAttributes
 						};
 					};
 					value=1;
+				};
+			};
+		};
+		class Attribute1
+		{
+			property="RespawnTemplates";
+			expression="true";
+			class Value
+			{
+				class data
+				{
+					class type
+					{
+						type[]=
+						{
+							"ARRAY"
+						};
+					};
 				};
 			};
 		};
@@ -1290,18 +1290,79 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8306.8721,76.060417,10067.928};
-						angles[]={6.2418771,2.3351603,0};
+						angles[]={6.2418733,2.3351631,0};
 					};
 					side="West";
 					flags=6;
 					class Attributes
 					{
 						skill=0.60000002;
-						description="Engineer";
+						description="Advanced engineer";
 						isPlayable=1;
 					};
 					id=31;
 					type="B_engineer_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="ace_isEngineer";
+							expression="if (_value != -1) then {_this setVariable ['ace_isEngineer',_value, true];}";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=2;
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02ENG";
+								};
+							};
+						};
+						class Attribute2
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.99000001;
+								};
+							};
+						};
+						nAttributes=3;
+					};
 				};
 			};
 			class Attributes

--- a/=BTC=co@30_Hearts_and_Minds.Altis/mission.sqm
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/mission.sqm
@@ -16,7 +16,7 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={8332.7754,117.25275,10068.063};
+		pos[]={8330.0225,187.05653,10023.455};
 		dir[]={0.053734943,-0.82017767,0.5696947};
 		up[]={0.077020578,0.57209378,0.81656778};
 		aside[]={0.99564278,3.8654252e-007,-0.093911856};
@@ -41,9 +41,6 @@ addons[]=
 	"A3_Characters_F",
 	"ace_explosives",
 	"A3_Modules_F_Curator_Curator",
-	"ace_respawn",
-	"ace_advanced_ballistics",
-	"ace_winddeflection",
 	"rhsusf_c_fmtv",
 	"rhsusf_c_RG33L"
 };
@@ -51,7 +48,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=19;
+		items=16;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -148,32 +145,11 @@ class AddonsMetaData
 		};
 		class Item14
 		{
-			className="ace_respawn";
-			name="ACE3 - Respawn";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item15
-		{
-			className="ace_advanced_ballistics";
-			name="ACE3 - Advanced Ballistics";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item16
-		{
-			className="ace_winddeflection";
-			name="ACE3 - Wind Deflection";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item17
-		{
 			className="rhsusf_c_fmtv";
 			name="FMTV Trucks";
 			url="http://www.rhsmods.org/";
 		};
-		class Item18
+		class Item15
 		{
 			className="rhsusf_c_RG33L";
 			name="RG33L MRAP";
@@ -202,6 +178,24 @@ class CustomAttributes
 		name="Multiplayer";
 		class Attribute0
 		{
+			property="RespawnTemplates";
+			expression="true";
+			class Value
+			{
+				class data
+				{
+					class type
+					{
+						type[]=
+						{
+							"ARRAY"
+						};
+					};
+				};
+			};
+		};
+		class Attribute1
+		{
 			property="RespawnButton";
 			expression="true";
 			class Value
@@ -219,10 +213,15 @@ class CustomAttributes
 				};
 			};
 		};
-		class Attribute1
+		nAttributes=2;
+	};
+	class Category1
+	{
+		name="Scenario";
+		class Attribute0
 		{
-			property="RespawnTemplates";
-			expression="true";
+			property="cba_settings_hash";
+			expression="false";
 			class Value
 			{
 				class data
@@ -234,15 +233,135 @@ class CustomAttributes
 							"ARRAY"
 						};
 					};
+					class value
+					{
+						items=4;
+						class Item0
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="#CBA_HASH#";
+							};
+						};
+						class Item1
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_respawn_savepredeathgear";
+										};
+									};
+								};
+							};
+						};
+						class Item2
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=0;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+								};
+							};
+						};
+						class Item3
+						{
+							class data
+							{
+								nil=1;
+								class type
+								{
+									type[]=
+									{
+										"ANY"
+									};
+								};
+							};
+						};
+					};
 				};
 			};
 		};
-		nAttributes=2;
-	};
-	class Category1
-	{
-		name="Scenario";
-		class Attribute0
+		class Attribute1
 		{
 			property="EnableDebugConsole";
 			expression="true";
@@ -261,7 +380,7 @@ class CustomAttributes
 				};
 			};
 		};
-		nAttributes=1;
+		nAttributes=2;
 	};
 };
 class Mission
@@ -293,7 +412,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=57;
+		items=52;
 		class Item0
 		{
 			dataType="Marker";
@@ -707,7 +826,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8323.1582,73.944031,10113.102};
-				angles[]={0.074527748,0.89397335,0.018663859};
+				angles[]={0.074525557,0.89397508,0.018657569};
 			};
 			side="Empty";
 			flags=4;
@@ -718,6 +837,29 @@ class Mission
 			};
 			id=14;
 			type="Land_HelipadSquare_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ace_isRepairFacility";
+					expression="_this setVariable ['ace_isRepairFacility',_value, true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=1;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 		class Item11
 		{
@@ -1103,589 +1245,6 @@ class Mission
 		};
 		class Item24
 		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={8290.0527,56.416218,9962.876};
-			};
-			id=72;
-			type="ACE_ModuleRespawn";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ACE_ModuleRespawn_RemoveDeadBodiesDisconnected";
-					expression="_this setVariable ['RemoveDeadBodiesDisconnected',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ACE_ModuleRespawn_SavePreDeathGear";
-					expression="_this setVariable ['SavePreDeathGear',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=2;
-			};
-		};
-		class Item25
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={8320.5127,72.481377,10123.821};
-			};
-			id=74;
-			type="ACE_moduleAssignRepairFacility";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ACE_moduleAssignRepairFacility_role";
-					expression="_this setVariable ['role',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ACE_moduleAssignRepairFacility_EnableList";
-					expression="_this setVariable ['EnableList',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="";
-						};
-					};
-				};
-				nAttributes=2;
-			};
-		};
-		class Item26
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={8276.9385,56.550854,9954.5273};
-			};
-			id=75;
-			type="ACE_moduleRepairSettings";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ACE_moduleRepairSettings_fullRepairLocation";
-					expression="_this setVariable ['fullRepairLocation',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=2;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ACE_moduleRepairSettings_engineerSetting_fullRepair";
-					expression="_this setVariable ['engineerSetting_fullRepair',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="ACE_moduleRepairSettings_engineerSetting_Repair";
-					expression="_this setVariable ['engineerSetting_Repair',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute3
-				{
-					property="ACE_moduleRepairSettings_consumeItem_ToolKit";
-					expression="_this setVariable ['consumeItem_ToolKit',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute4
-				{
-					property="ACE_moduleRepairSettings_repairDamageThreshold";
-					expression="_this setVariable ['repairDamageThreshold',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0.60000002;
-						};
-					};
-				};
-				class Attribute5
-				{
-					property="ACE_moduleRepairSettings_wheelRepairRequiredItems";
-					expression="_this setVariable ['wheelRepairRequiredItems',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute6
-				{
-					property="ACE_moduleRepairSettings_repairDamageThreshold_Engineer";
-					expression="_this setVariable ['repairDamageThreshold_Engineer',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0.40000001;
-						};
-					};
-				};
-				class Attribute7
-				{
-					property="ACE_moduleRepairSettings_engineerSetting_Wheel";
-					expression="_this setVariable ['engineerSetting_Wheel',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute8
-				{
-					property="ACE_moduleRepairSettings_addSpareParts";
-					expression="_this setVariable ['addSpareParts',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=9;
-			};
-		};
-		class Item27
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={8282.9766,57.551399,9962.9941};
-			};
-			id=80;
-			type="ace_advanced_ballistics_ModuleSettings";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ace_advanced_ballistics_ModuleSettings_simulationRadius";
-					expression="_this setVariable ['simulationRadius',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=3000;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ace_advanced_ballistics_ModuleSettings_barrelLengthInfluenceEnabled";
-					expression="_this setVariable ['barrelLengthInfluenceEnabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="ace_advanced_ballistics_ModuleSettings_bulletTraceEnabled";
-					expression="_this setVariable ['bulletTraceEnabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute3
-				{
-					property="ace_advanced_ballistics_ModuleSettings_simulationInterval";
-					expression="_this setVariable ['simulationInterval',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute4
-				{
-					property="ace_advanced_ballistics_ModuleSettings_disabledInFullAutoMode";
-					expression="_this setVariable ['disabledInFullAutoMode',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute5
-				{
-					property="ace_advanced_ballistics_ModuleSettings_simulateForEveryone";
-					expression="_this setVariable ['simulateForEveryone',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute6
-				{
-					property="ace_advanced_ballistics_ModuleSettings_simulateForSnipers";
-					expression="_this setVariable ['simulateForSnipers',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute7
-				{
-					property="ace_advanced_ballistics_ModuleSettings_simulateForGroupMembers";
-					expression="_this setVariable ['simulateForGroupMembers',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute8
-				{
-					property="ace_advanced_ballistics_ModuleSettings_ammoTemperatureEnabled";
-					expression="_this setVariable ['ammoTemperatureEnabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute9
-				{
-					property="ace_advanced_ballistics_ModuleSettings_enabled";
-					expression="_this setVariable ['enabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=10;
-			};
-		};
-		class Item28
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={8277.0547,58.537991,9962.7119};
-			};
-			id=81;
-			type="ace_winddeflection_ModuleSettings";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ace_winddeflection_ModuleSettings_simulationInterval";
-					expression="_this setVariable ['simulationInterval',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0.050000001;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ace_winddeflection_ModuleSettings_enabled";
-					expression="_this setVariable ['enabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="ace_winddeflection_ModuleSettings_simulationRadius";
-					expression="_this setVariable ['simulationRadius',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=3000;
-						};
-					};
-				};
-				class Attribute3
-				{
-					property="ace_winddeflection_ModuleSettings_vehicleEnabled";
-					expression="_this setVariable ['vehicleEnabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=4;
-			};
-		};
-		class Item29
-		{
 			dataType="Group";
 			side="West";
 			class Entities
@@ -1714,7 +1273,7 @@ class Mission
 			};
 			id=89;
 		};
-		class Item30
+		class Item25
 		{
 			dataType="Group";
 			side="West";
@@ -1744,7 +1303,7 @@ class Mission
 			};
 			id=91;
 		};
-		class Item31
+		class Item26
 		{
 			dataType="Group";
 			side="West";
@@ -1774,7 +1333,7 @@ class Mission
 			};
 			id=93;
 		};
-		class Item32
+		class Item27
 		{
 			dataType="Group";
 			side="West";
@@ -1804,7 +1363,7 @@ class Mission
 			};
 			id=95;
 		};
-		class Item33
+		class Item28
 		{
 			dataType="Group";
 			side="West";
@@ -1834,7 +1393,7 @@ class Mission
 			};
 			id=97;
 		};
-		class Item34
+		class Item29
 		{
 			dataType="Group";
 			side="West";
@@ -1864,7 +1423,7 @@ class Mission
 			};
 			id=99;
 		};
-		class Item35
+		class Item30
 		{
 			dataType="Group";
 			side="West";
@@ -1894,7 +1453,7 @@ class Mission
 			};
 			id=101;
 		};
-		class Item36
+		class Item31
 		{
 			dataType="Group";
 			side="West";
@@ -1924,7 +1483,7 @@ class Mission
 			};
 			id=103;
 		};
-		class Item37
+		class Item32
 		{
 			dataType="Group";
 			side="West";
@@ -1956,7 +1515,7 @@ class Mission
 			id=105;
 			atlOffset=0.028755188;
 		};
-		class Item38
+		class Item33
 		{
 			dataType="Group";
 			side="West";
@@ -1988,7 +1547,7 @@ class Mission
 			id=107;
 			atlOffset=0.072166443;
 		};
-		class Item39
+		class Item34
 		{
 			dataType="Group";
 			side="West";
@@ -2018,7 +1577,7 @@ class Mission
 			};
 			id=109;
 		};
-		class Item40
+		class Item35
 		{
 			dataType="Group";
 			side="West";
@@ -2048,7 +1607,7 @@ class Mission
 			};
 			id=111;
 		};
-		class Item41
+		class Item36
 		{
 			dataType="Group";
 			side="West";
@@ -2078,7 +1637,7 @@ class Mission
 			};
 			id=113;
 		};
-		class Item42
+		class Item37
 		{
 			dataType="Group";
 			side="West";
@@ -2108,7 +1667,7 @@ class Mission
 			};
 			id=115;
 		};
-		class Item43
+		class Item38
 		{
 			dataType="Group";
 			side="West";
@@ -2138,7 +1697,7 @@ class Mission
 			};
 			id=117;
 		};
-		class Item44
+		class Item39
 		{
 			dataType="Group";
 			side="West";
@@ -2168,7 +1727,7 @@ class Mission
 			};
 			id=119;
 		};
-		class Item45
+		class Item40
 		{
 			dataType="Group";
 			side="West";
@@ -2198,7 +1757,7 @@ class Mission
 			};
 			id=121;
 		};
-		class Item46
+		class Item41
 		{
 			dataType="Group";
 			side="West";
@@ -2228,7 +1787,7 @@ class Mission
 			};
 			id=123;
 		};
-		class Item47
+		class Item42
 		{
 			dataType="Group";
 			side="West";
@@ -2260,7 +1819,7 @@ class Mission
 			id=125;
 			atlOffset=0.0039749146;
 		};
-		class Item48
+		class Item43
 		{
 			dataType="Group";
 			side="West";
@@ -2292,7 +1851,7 @@ class Mission
 			id=127;
 			atlOffset=0.0039749146;
 		};
-		class Item49
+		class Item44
 		{
 			dataType="Group";
 			side="West";
@@ -2322,7 +1881,7 @@ class Mission
 			};
 			id=129;
 		};
-		class Item50
+		class Item45
 		{
 			dataType="Group";
 			side="West";
@@ -2352,7 +1911,7 @@ class Mission
 			};
 			id=131;
 		};
-		class Item51
+		class Item46
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2394,7 +1953,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item52
+		class Item47
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2436,7 +1995,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item53
+		class Item48
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2478,7 +2037,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item54
+		class Item49
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -2490,7 +2049,7 @@ class Mission
 			id=153;
 			type="HeadlessClient_F";
 		};
-		class Item55
+		class Item50
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2533,7 +2092,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item56
+		class Item51
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2573,27 +2132,6 @@ class Mission
 					};
 				};
 				nAttributes=1;
-			};
-		};
-	};
-	class Connections
-	{
-		class LinkIDProvider
-		{
-			nextID=1;
-		};
-		class Links
-		{
-			items=1;
-			class Item0
-			{
-				linkID=0;
-				item0=74;
-				item1=14;
-				class CustomData
-				{
-					type="Sync";
-				};
 			};
 		};
 	};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/mission_Tanoa.sqm
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/mission_Tanoa.sqm
@@ -39,9 +39,6 @@ addons[]=
 	"A3_Characters_F",
 	"ace_explosives",
 	"A3_Modules_F_Curator_Curator",
-	"ace_respawn",
-	"ace_advanced_ballistics",
-	"ace_winddeflection",
 	"RHS_US_A2Port_Armor",
 	"rhsusf_vehicles",
 	"rhsusf_c_fmtv",
@@ -51,7 +48,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=19;
+		items=16;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -137,43 +134,22 @@ class AddonsMetaData
 		};
 		class Item12
 		{
-			className="ace_respawn";
-			name="ACE3 - Respawn";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item13
-		{
-			className="ace_advanced_ballistics";
-			name="ACE3 - Advanced Ballistics";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item14
-		{
-			className="ace_winddeflection";
-			name="ACE3 - Wind Deflection";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item15
-		{
 			className="RHS_US_A2Port_Armor";
 			name="M2 Bradley IFV";
 			url="http://www.rhsmods.org/";
 		};
-		class Item16
+		class Item13
 		{
 			className="rhsusf_vehicles";
 			name="rhsusf_vehicles";
 		};
-		class Item17
+		class Item14
 		{
 			className="rhsusf_c_fmtv";
 			name="FMTV Trucks";
 			url="http://www.rhsmods.org/";
 		};
-		class Item18
+		class Item15
 		{
 			className="rhsusf_c_RG33L";
 			name="RG33L MRAP";
@@ -202,24 +178,6 @@ class CustomAttributes
 		name="Multiplayer";
 		class Attribute0
 		{
-			property="RespawnTemplates";
-			expression="true";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"ARRAY"
-						};
-					};
-				};
-			};
-		};
-		class Attribute1
-		{
 			property="RespawnButton";
 			expression="true";
 			class Value
@@ -234,6 +192,24 @@ class CustomAttributes
 						};
 					};
 					value=1;
+				};
+			};
+		};
+		class Attribute1
+		{
+			property="RespawnTemplates";
+			expression="true";
+			class Value
+			{
+				class data
+				{
+					class type
+					{
+						type[]=
+						{
+							"ARRAY"
+						};
+					};
 				};
 			};
 		};
@@ -293,7 +269,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=57;
+		items=52;
 		class Item0
 		{
 			dataType="Marker";
@@ -416,7 +392,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={4253.375,19.517353,3990.375};
-				angles[]={6.2671871,0.52168256,0.058600098};
+				angles[]={6.2671809,0.52167892,0.058608156};
 			};
 			side="Empty";
 			flags=4;
@@ -430,6 +406,25 @@ class Mission
 			class CustomAttributes
 			{
 				class Attribute0
+				{
+					property="ace_isRepairFacility";
+					expression="_this setVariable ['ace_isRepairFacility',_value, true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=1;
+						};
+					};
+				};
+				class Attribute1
 				{
 					property="ace_isMedicalFacility";
 					expression="_this setVariable [""ace_medical_isMedicalFacility"",_value,true];";
@@ -448,7 +443,7 @@ class Mission
 						};
 					};
 				};
-				nAttributes=1;
+				nAttributes=2;
 			};
 		};
 		class Item6
@@ -1231,596 +1226,6 @@ class Mission
 		};
 		class Item19
 		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={4019.623,-3.7731285,3926.0391};
-				angles[]={0.021331646,0,6.2645183};
-			};
-			id=72;
-			type="ACE_ModuleRespawn";
-			atlOffset=0.41534662;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ACE_ModuleRespawn_RemoveDeadBodiesDisconnected";
-					expression="_this setVariable ['RemoveDeadBodiesDisconnected',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ACE_ModuleRespawn_SavePreDeathGear";
-					expression="_this setVariable ['SavePreDeathGear',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=2;
-			};
-		};
-		class Item20
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={4261.6733,23.156195,3986.2942};
-				angles[]={0,5.9109015,0};
-			};
-			id=74;
-			type="ACE_moduleAssignRepairFacility";
-			atlOffset=3.0099945;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ACE_moduleAssignRepairFacility_role";
-					expression="_this setVariable ['role',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ACE_moduleAssignRepairFacility_EnableList";
-					expression="_this setVariable ['EnableList',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="";
-						};
-					};
-				};
-				nAttributes=2;
-			};
-		};
-		class Item21
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={4006.5088,-4.0501103,3917.6904};
-				angles[]={0.018663859,0,0.013332055};
-			};
-			id=75;
-			type="ACE_moduleRepairSettings";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ACE_moduleRepairSettings_fullRepairLocation";
-					expression="_this setVariable ['fullRepairLocation',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=2;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ACE_moduleRepairSettings_engineerSetting_fullRepair";
-					expression="_this setVariable ['engineerSetting_fullRepair',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="ACE_moduleRepairSettings_engineerSetting_Repair";
-					expression="_this setVariable ['engineerSetting_Repair',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute3
-				{
-					property="ACE_moduleRepairSettings_consumeItem_ToolKit";
-					expression="_this setVariable ['consumeItem_ToolKit',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute4
-				{
-					property="ACE_moduleRepairSettings_repairDamageThreshold";
-					expression="_this setVariable ['repairDamageThreshold',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0.60000002;
-						};
-					};
-				};
-				class Attribute5
-				{
-					property="ACE_moduleRepairSettings_wheelRepairRequiredItems";
-					expression="_this setVariable ['wheelRepairRequiredItems',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute6
-				{
-					property="ACE_moduleRepairSettings_repairDamageThreshold_Engineer";
-					expression="_this setVariable ['repairDamageThreshold_Engineer',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0.40000001;
-						};
-					};
-				};
-				class Attribute7
-				{
-					property="ACE_moduleRepairSettings_engineerSetting_Wheel";
-					expression="_this setVariable ['engineerSetting_Wheel',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute8
-				{
-					property="ACE_moduleRepairSettings_addSpareParts";
-					expression="_this setVariable ['addSpareParts',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=9;
-			};
-		};
-		class Item22
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={4012.5469,-2.5048904,3926.1572};
-			};
-			id=80;
-			type="ace_advanced_ballistics_ModuleSettings";
-			atlOffset=1.6238766;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ace_advanced_ballistics_ModuleSettings_simulationRadius";
-					expression="_this setVariable ['simulationRadius',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=3000;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ace_advanced_ballistics_ModuleSettings_barrelLengthInfluenceEnabled";
-					expression="_this setVariable ['barrelLengthInfluenceEnabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="ace_advanced_ballistics_ModuleSettings_bulletTraceEnabled";
-					expression="_this setVariable ['bulletTraceEnabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute3
-				{
-					property="ace_advanced_ballistics_ModuleSettings_simulationInterval";
-					expression="_this setVariable ['simulationInterval',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute4
-				{
-					property="ace_advanced_ballistics_ModuleSettings_disabledInFullAutoMode";
-					expression="_this setVariable ['disabledInFullAutoMode',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute5
-				{
-					property="ace_advanced_ballistics_ModuleSettings_simulateForEveryone";
-					expression="_this setVariable ['simulateForEveryone',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute6
-				{
-					property="ace_advanced_ballistics_ModuleSettings_simulateForSnipers";
-					expression="_this setVariable ['simulateForSnipers',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute7
-				{
-					property="ace_advanced_ballistics_ModuleSettings_simulateForGroupMembers";
-					expression="_this setVariable ['simulateForGroupMembers',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute8
-				{
-					property="ace_advanced_ballistics_ModuleSettings_ammoTemperatureEnabled";
-					expression="_this setVariable ['ammoTemperatureEnabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute9
-				{
-					property="ace_advanced_ballistics_ModuleSettings_enabled";
-					expression="_this setVariable ['enabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=10;
-			};
-		};
-		class Item23
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={4006.625,0,3925.875};
-			};
-			id=81;
-			type="ace_winddeflection_ModuleSettings";
-			atlOffset=4.1486669;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ace_winddeflection_ModuleSettings_simulationInterval";
-					expression="_this setVariable ['simulationInterval',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0.050000001;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ace_winddeflection_ModuleSettings_enabled";
-					expression="_this setVariable ['enabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="ace_winddeflection_ModuleSettings_simulationRadius";
-					expression="_this setVariable ['simulationRadius',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=3000;
-						};
-					};
-				};
-				class Attribute3
-				{
-					property="ace_winddeflection_ModuleSettings_vehicleEnabled";
-					expression="_this setVariable ['vehicleEnabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=4;
-			};
-		};
-		class Item24
-		{
 			dataType="Group";
 			side="West";
 			class Entities
@@ -1912,7 +1317,7 @@ class Mission
 			id=89;
 			atlOffset=1.9073486e-006;
 		};
-		class Item25
+		class Item20
 		{
 			dataType="Group";
 			side="West";
@@ -2005,7 +1410,7 @@ class Mission
 			id=91;
 			atlOffset=-3.8146973e-006;
 		};
-		class Item26
+		class Item21
 		{
 			dataType="Group";
 			side="West";
@@ -2096,7 +1501,7 @@ class Mission
 			};
 			id=93;
 		};
-		class Item27
+		class Item22
 		{
 			dataType="Group";
 			side="West";
@@ -2189,7 +1594,7 @@ class Mission
 			id=95;
 			atlOffset=-3.8146973e-006;
 		};
-		class Item28
+		class Item23
 		{
 			dataType="Group";
 			side="West";
@@ -2280,7 +1685,7 @@ class Mission
 			};
 			id=97;
 		};
-		class Item29
+		class Item24
 		{
 			dataType="Group";
 			side="West";
@@ -2371,7 +1776,7 @@ class Mission
 			};
 			id=99;
 		};
-		class Item30
+		class Item25
 		{
 			dataType="Group";
 			side="West";
@@ -2464,7 +1869,7 @@ class Mission
 			id=101;
 			atlOffset=1.9073486e-006;
 		};
-		class Item31
+		class Item26
 		{
 			dataType="Group";
 			side="West";
@@ -2557,7 +1962,7 @@ class Mission
 			id=103;
 			atlOffset=-3.8146973e-006;
 		};
-		class Item32
+		class Item27
 		{
 			dataType="Group";
 			side="West";
@@ -2650,7 +2055,7 @@ class Mission
 			id=105;
 			atlOffset=-1.9073486e-006;
 		};
-		class Item33
+		class Item28
 		{
 			dataType="Group";
 			side="West";
@@ -2743,7 +2148,7 @@ class Mission
 			id=107;
 			atlOffset=3.8146973e-006;
 		};
-		class Item34
+		class Item29
 		{
 			dataType="Group";
 			side="West";
@@ -2775,7 +2180,7 @@ class Mission
 			id=109;
 			atlOffset=-1.9073486e-006;
 		};
-		class Item35
+		class Item30
 		{
 			dataType="Group";
 			side="West";
@@ -2805,7 +2210,7 @@ class Mission
 			};
 			id=111;
 		};
-		class Item36
+		class Item31
 		{
 			dataType="Group";
 			side="West";
@@ -2898,7 +2303,7 @@ class Mission
 			id=113;
 			atlOffset=-3.8146973e-006;
 		};
-		class Item37
+		class Item32
 		{
 			dataType="Group";
 			side="West";
@@ -2989,7 +2394,7 @@ class Mission
 			};
 			id=115;
 		};
-		class Item38
+		class Item33
 		{
 			dataType="Group";
 			side="West";
@@ -3080,7 +2485,7 @@ class Mission
 			};
 			id=117;
 		};
-		class Item39
+		class Item34
 		{
 			dataType="Group";
 			side="West";
@@ -3173,7 +2578,7 @@ class Mission
 			id=119;
 			atlOffset=-3.8146973e-006;
 		};
-		class Item40
+		class Item35
 		{
 			dataType="Group";
 			side="West";
@@ -3266,7 +2671,7 @@ class Mission
 			id=121;
 			atlOffset=-3.8146973e-006;
 		};
-		class Item41
+		class Item36
 		{
 			dataType="Group";
 			side="West";
@@ -3359,7 +2764,7 @@ class Mission
 			id=123;
 			atlOffset=-3.8146973e-006;
 		};
-		class Item42
+		class Item37
 		{
 			dataType="Group";
 			side="West";
@@ -3391,7 +2796,7 @@ class Mission
 			id=125;
 			atlOffset=-5.7220459e-006;
 		};
-		class Item43
+		class Item38
 		{
 			dataType="Group";
 			side="West";
@@ -3423,7 +2828,7 @@ class Mission
 			id=127;
 			atlOffset=-3.8146973e-006;
 		};
-		class Item44
+		class Item39
 		{
 			dataType="Group";
 			side="West";
@@ -3455,7 +2860,7 @@ class Mission
 			id=129;
 			atlOffset=5.7220459e-006;
 		};
-		class Item45
+		class Item40
 		{
 			dataType="Group";
 			side="West";
@@ -3485,7 +2890,7 @@ class Mission
 			};
 			id=131;
 		};
-		class Item46
+		class Item41
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3528,7 +2933,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item47
+		class Item42
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3608,7 +3013,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item48
+		class Item43
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3688,7 +3093,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item49
+		class Item44
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3769,7 +3174,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item50
+		class Item45
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3849,7 +3254,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item51
+		class Item46
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3891,7 +3296,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item52
+		class Item47
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3933,7 +3338,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item53
+		class Item48
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3975,7 +3380,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item54
+		class Item49
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3988,7 +3393,7 @@ class Mission
 			id=246;
 			type="HeadlessClient_F";
 		};
-		class Item55
+		class Item50
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4031,7 +3436,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item56
+		class Item51
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4071,27 +3476,6 @@ class Mission
 					};
 				};
 				nAttributes=1;
-			};
-		};
-	};
-	class Connections
-	{
-		class LinkIDProvider
-		{
-			nextID=1;
-		};
-		class Links
-		{
-			items=1;
-			class Item0
-			{
-				linkID=0;
-				item0=74;
-				item1=14;
-				class CustomData
-				{
-					type="Sync";
-				};
 			};
 		};
 	};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/mission_Tanoa.sqm
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/mission_Tanoa.sqm
@@ -178,6 +178,24 @@ class CustomAttributes
 		name="Multiplayer";
 		class Attribute0
 		{
+			property="RespawnTemplates";
+			expression="true";
+			class Value
+			{
+				class data
+				{
+					class type
+					{
+						type[]=
+						{
+							"ARRAY"
+						};
+					};
+				};
+			};
+		};
+		class Attribute1
+		{
 			property="RespawnButton";
 			expression="true";
 			class Value
@@ -195,10 +213,15 @@ class CustomAttributes
 				};
 			};
 		};
-		class Attribute1
+		nAttributes=2;
+	};
+	class Category1
+	{
+		name="Scenario";
+		class Attribute0
 		{
-			property="RespawnTemplates";
-			expression="true";
+			property="cba_settings_hash";
+			expression="false";
 			class Value
 			{
 				class data
@@ -210,15 +233,312 @@ class CustomAttributes
 							"ARRAY"
 						};
 					};
+					class value
+					{
+						items=4;
+						class Item0
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="#CBA_HASH#";
+							};
+						};
+						class Item1
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=4;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_enablefor";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_rearm_level";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_respawn_savepredeathgear";
+										};
+									};
+									class Item3
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_cargo_enable";
+										};
+									};
+								};
+							};
+						};
+						class Item2
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=4;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item3
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=0;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+								};
+							};
+						};
+						class Item3
+						{
+							class data
+							{
+								nil=1;
+								class type
+								{
+									type[]=
+									{
+										"ANY"
+									};
+								};
+							};
+						};
+					};
 				};
 			};
 		};
-		nAttributes=2;
-	};
-	class Category1
-	{
-		name="Scenario";
-		class Attribute0
+		class Attribute1
 		{
 			property="EnableDebugConsole";
 			expression="true";
@@ -237,7 +557,7 @@ class CustomAttributes
 				};
 			};
 		};
-		nAttributes=1;
+		nAttributes=2;
 	};
 };
 class Mission

--- a/=BTC=co@30_Hearts_and_Minds.Altis/mission_Tanoa.sqm
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/mission_Tanoa.sqm
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={4238.0225,23.444588,3976.3384};
-		dir[]={0.0033626116,-0.12773004,0.9918986};
-		up[]={0.00043315504,0.99179304,0.12790467};
-		aside[]={1.0000873,-7.9231859e-007,-0.0033897087};
+		pos[]={4207.9165,39.892441,4004.0476};
+		dir[]={0.23425245,-0.75864172,0.60809433};
+		up[]={0.2727313,0.6514526,0.70798182};
+		aside[]={0.93324167,-1.1265511e-006,-0.35950708};
 	};
 };
 binarizationWanted=0;
@@ -178,24 +178,6 @@ class CustomAttributes
 		name="Multiplayer";
 		class Attribute0
 		{
-			property="RespawnTemplates";
-			expression="true";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"ARRAY"
-						};
-					};
-				};
-			};
-		};
-		class Attribute1
-		{
 			property="RespawnButton";
 			expression="true";
 			class Value
@@ -210,6 +192,24 @@ class CustomAttributes
 						};
 					};
 					value=1;
+				};
+			};
+		};
+		class Attribute1
+		{
+			property="RespawnTemplates";
+			expression="true";
+			class Value
+			{
+				class data
+				{
+					class type
+					{
+						type[]=
+						{
+							"ARRAY"
+						};
+					};
 				};
 			};
 		};
@@ -1349,20 +1349,20 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={4213.9482,19.380545,4021.1812};
-						angles[]={6.2698536,4.1308832,6.2698536};
+						position[]={4213.9482,19.380543,4021.1812};
+						angles[]={6.2698507,4.1308804,6.2698507};
 					};
 					side="West";
 					flags=6;
 					class Attributes
 					{
 						skill=0.60000002;
-						description="Engineer";
+						description="Advanced engineer";
 						isPlayable=1;
 					};
 					id=31;
 					type="B_engineer_F";
-					atlOffset=3.8146973e-006;
+					atlOffset=1.9073486e-006;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -1386,6 +1386,44 @@ class Mission
 						};
 						class Attribute1
 						{
+							property="ace_isEngineer";
+							expression="if (_value != -1) then {_this setVariable ['ace_isEngineer',_value, true];}";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=2;
+								};
+							};
+						};
+						class Attribute2
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02ENG";
+								};
+							};
+						};
+						class Attribute3
+						{
 							property="pitch";
 							expression="_this setpitch _value;";
 							class Value
@@ -1403,7 +1441,7 @@ class Mission
 								};
 							};
 						};
-						class Attribute2
+						class Attribute4
 						{
 							property="ace_isSurrendered";
 							expression="if (_value) then {[objNull,[_this],true] call ace_captives_fnc_moduleSurrender}";
@@ -1422,7 +1460,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						nAttributes=5;
 					};
 				};
 			};
@@ -1430,7 +1468,7 @@ class Mission
 			{
 			};
 			id=30;
-			atlOffset=3.8146973e-006;
+			atlOffset=1.9073486e-006;
 		};
 		class Item18
 		{


### PR DESCRIPTION
**When merged this pull request will:**
- Since ACE 3.12, ACE module are deprecated (https://slack-files.com/T047TJFFL-F8CF8TVJR-e953dbf392)
- Since ACE 3.12, ACE setting is suppose to be choose in mission.sqm or on the fly by server admin or client (https://github.com/CBATeam/CBA_A3/wiki/CBA-Settings-System#how-to-use-already-existing-settings). So ACE setting entry in mission parameters is no more usefull. This remove ACE setting in mission parameters.
- OPTION must be use for H&M are now directly inside the mission.sqm
- Add debugconsole for admin ONLY

- [x] add Advanced engineer
- [x] test logistic point as repair point

**Final test:**
- [x] local
- [x] server