### PR TITLE
FIX: Remove everybody can disarm IED option in mission parameters

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -20,7 +20,6 @@ _p_civ_veh = "btc_p_civ_veh" call BIS_fnc_getParamValue;
 
 //<< IED options >>
 btc_p_ied = ("btc_p_ied" call BIS_fnc_getParamValue)/2;
-ace_explosives_RequireSpecialist  = ("btc_p_engineer" call BIS_fnc_getParamValue) isEqualTo 0;
 
 //<< Hideout/Cache options >>
 _hideout_n = "btc_p_hideout_n" call BIS_fnc_getParamValue;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -77,12 +77,6 @@ class Params {
 		texts[]={"Off","Low","Normal","High"};
 		default = 2;
 	};
-	class btc_p_engineer {
-		title = "			Everybody can disarm IED:";
-		values[]={0,1};
-		texts[]={"Off","On"};
-		default = 0;
-	};
 	class btc_p_hideout_cache_title {
 		title = "<< Hideout/Cache options >>";
 		values[]={0};


### PR DESCRIPTION
- FIX: Remove everybody can disarm IED option in mission parameters.

**When merged this pull request will:**
- Remove everybody can disarm IED option in mission parameter

**Final test:**
- [x] local
- [x] server