### PR TITLE
FIX: Sometimes engine of vehicles can't be turn ON

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
@@ -4,7 +4,7 @@ private _pos = _this select 1;
 private _dir = _this select 2;
 private _textures = if (count _this > 3) then {_this select 3} else {[]};
 
-_veh  = _type createVehicle [0,0,0];
+_veh  = createVehicle [_type, ASLToATL _pos, [], 0, "CAN_COLLIDE"];
 _veh setDir _dir;
 _veh setPosASL _pos;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Sometimes the engine of vehicles can't be turn on due to the spawn at 0,0,0 position
- the 0,0,0 position is underwater so the engine takes damage from the water a little and randomnly.

- [x] locally the engine of repaired vehicle can be turn on
- [x] the vehicle are not damaged during database loading

**Final test:**
- [x] local
- [x] server

  