### PR TITLE
FIX: Markers are not deleted when side mission convoy/capture officer failed

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/capture_officer.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/capture_officer.sqf
@@ -124,6 +124,7 @@ if (btc_side_failed) exitWith {
 		(crew _x) joinSilent _group;
 		_group call btc_fnc_data_add_group;
 	} forEach _vehs;
+	[_markers, [_trigger], [], []] call btc_fnc_delete;
 };
 
 50 call btc_fnc_rep_change;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/capture_officer.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/capture_officer.sqf
@@ -117,7 +117,6 @@ if (btc_side_aborted || !(Alive _captive)) exitWith {
 
 if (btc_side_failed) exitWith {
 	14 remoteExec ["btc_fnc_task_fail", 0];
-	deleteVehicle _trigger;
 	_group setVariable ["no_cache",false];
 	{
 		_group = createGroup btc_enemy_side;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/convoy.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/convoy.sqf
@@ -94,7 +94,6 @@ _wp setWaypointStatements ["true", "btc_side_failed = true"];
 waitUntil {sleep 5; (btc_side_aborted || btc_side_failed || ({ canMove _x } count _vehs == 0) || (_group isEqualTo grpNull))};
 
 btc_side_assigned = false;publicVariable "btc_side_assigned";
-
 if (btc_side_aborted) exitWith {
 	12 remoteExec ["btc_fnc_task_fail", 0];
 	[_markers, _vehs, [], [_group]] call btc_fnc_delete;
@@ -108,6 +107,7 @@ if (btc_side_failed) exitWith {
 		(crew _x) joinSilent _group;
 		_group call btc_fnc_data_add_group;
 	} forEach _vehs;
+	[_markers, [], [], []] call btc_fnc_delete;
 };
 
 50 call btc_fnc_rep_change;


### PR DESCRIPTION
**When merged this pull request will:**
- when side mission failed (because the convoy reach the city or fail to find a path), markers are not deleted.

**Final test:**
- [x] local
- [x] server
  