### PR TITLE
Keep CfgFunctions in description.ext

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/functions.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/functions.hpp
@@ -1,9 +1,7 @@
-class CfgFunctions {
-    class btc {
-        class misc {
-            class eh_veh_init {
-                file = "core\fnc\eh\veh_init.sqf";//preInit = 1;
-            };
+class btc {
+    class misc {
+        class eh_veh_init {
+            file = "core\fnc\eh\veh_init.sqf";//preInit = 1;
         };
     };
-};  
+};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/description.ext
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/description.ext
@@ -31,7 +31,11 @@ class RscTitles {
 
 #include "core\fnc\task\tasktypes.hpp"
 
-#include "core\def\functions.hpp"
+class CfgFunctions {
+    #include "core\def\functions.hpp"
+    // add your own functions below
+    
+};
 
 #include "core\fnc\eh\extended_InitPost_EH.hpp"
 #include "core\fnc\eh\extended_PreInit_EH.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Move the CfgFunctions declaration from def/functions.hpp to description.ext
    - Reason is that in case someone is editing the mission, to be able to add custom functions to it without having to edit a source file


**Final test:**
- [x] local
- [x] server

**Screenshots**
n/a