### PR TITLE
Add: Optimize city creation by using Simple objects

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/create.sqf
@@ -1,31 +1,23 @@
 
-private ["_position","_type","_name","_radius_x","_radius_y","_has_en","_id","_city"];
+params ["_position","_type","_name","_radius_x","_radius_y","_has_en"];
 
-_position = _this select 0;
-_type = _this select 1;
-_name = _this select 2;
-_radius_x = _this select 3;
-_radius_y = _this select 4;
-_has_en = _this select 5;//BOOL
-_id = count btc_city_all;
+private _id = count btc_city_all;
 
-_city = "Land_Ammobox_rounds_F" createVehicle _position;
-_city hideObjectGlobal true;
-_city allowDamage false;
-_city enableSimulation false;
-_city setVariable ["activating",false];
-_city setVariable ["initialized",false];
-_city setVariable ["id",_id];
-_city setVariable ["name",_name];
-_city setVariable ["RadiusX",_radius_x];
-_city setVariable ["RadiusY",_radius_y];
-_city setVariable ["active",false];
-_city setVariable ["type",_type];
-_city setVariable ["spawn_more",false];
-_city setVariable ["data_units",[]];
-_city setVariable ["occupied",_has_en];
+private _city = createSimpleObject ["a3\structures_f_epb\items\military\ammobox_rounds_f.p3d", [_position select 0, _position select 1, getTerrainHeightASL _position]];
+hideObjectGlobal _city;
+_city setVariable ["activating", false];
+_city setVariable ["initialized", false];
+_city setVariable ["id", _id];
+_city setVariable ["name", _name];
+_city setVariable ["RadiusX", _radius_x];
+_city setVariable ["RadiusY", _radius_y];
+_city setVariable ["active", false];
+_city setVariable ["type", _type];
+_city setVariable ["spawn_more", false];
+_city setVariable ["data_units", []];
+_city setVariable ["occupied", _has_en];
 if (btc_p_sea) then {
-	_city setVariable ["hasbeach", (((selectBestPlaces [_position,0.8*(_radius_x+_radius_y), "sea",10,1]) select 0 select 1) isEqualTo 1)];
+	_city setVariable ["hasbeach", ((selectBestPlaces [_position, 0.8*(_radius_x+_radius_y), "sea", 10, 1]) select 0 select 1) isEqualTo 1];
 };
 
 btc_city_all set [_id,_city];


### PR DESCRIPTION
**When merged this pull request will:**
- Use simple objects instead of objects for city location
- use `private` and `params` commands.
- City location is no more visible/editable from Zeus.

**Final test:**
- [x] local
- [x] server