### PR TITLE
FIX: Syntax error from btc_fnc_lift_hud_loop

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_hud_loop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_hud_loop.sqf
@@ -41,10 +41,7 @@ if (!isNull _cargo) then {
 	_cargo_z   = ((getPosATL _chopper) select 2) - (_cargo_pos select 2);
 	_obj_img ctrlShow true;
 	_hud_x   = _cargo_x / 100;
-	switch (true) do {
-		case (_cargo_y < 0): {_hud_y = (abs _cargo_y) / 100};
-		case (_cargo_y > 0): {_hud_y = (0 - _cargo_y) / 100};
-	};
+	_hud_y   = - _cargo_y / 100;
 	_hud_x_1 = (btc_lift_HUD_x + _hud_x) * safezoneW + safezoneX;
 	_hud_y_1 = (btc_lift_HUD_y + _hud_y) * safezoneH + safezoneY;
 	_obj_img ctrlsetposition [_hud_x_1, _hud_y_1];


### PR DESCRIPTION
**When merged this pull request will:**
- When `_cargo_y = 0` the   `_hud_y`  was not define resulting an error : 
```
21:01:19 Error in expression <log str([_hud_x_1, _hud_y_1]);
_obj_img ctrlsetposition [_hud_x_1, _hud_y_1];
_o>
21:01:19   Error position: <ctrlsetposition [_hud_x_1, _hud_y_1];
_o>
21:01:19   Error Type Nombre,Pas un chiffre, Nombre attendu
```

**Final test:**
- [x] local
- [x] server