### PR TITLE
Add: Arsenal type parameter

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -54,6 +54,7 @@ btc_p_veh_armed_spawn_more = ("btc_p_veh_armed_spawn_more" call BIS_fnc_getParam
 btc_p_side_mission_cycle = ("btc_p_side_mission_cycle" call BIS_fnc_getParamValue) isEqualTo 1;
 
 //<< Other options >>
+btc_p_arsenalType = "btc_p_arsenalType" call BIS_fnc_getParamValue;
 _p_rep = "btc_p_rep" call BIS_fnc_getParamValue;
 btc_p_garage = ("btc_p_garage" call BIS_fnc_getParamValue) isEqualTo 1;
 _p_city_radius = ("btc_p_city_radius" call BIS_fnc_getParamValue) * 100;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -242,7 +242,7 @@ class Params {
 	class btc_p_arsenalType { // Type of the arsenal:
 		title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE"]);
 		values[]={0,1,2,3,4};
-		texts[]={$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BIS,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BA,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BA_PLUS,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_ACE,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_ACE_PLUS}; //texts[]={"BIS - Vanilla","BIS - Vanilla and ACE 3","BIS - Vanilla und ACE 3 (scroll wheel action)","ACE 3","ACE 3 (scroll wheel action)"};
+		texts[]={$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BIS,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BA,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BA_PLUS,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_ACE,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_ACE_PLUS}; //texts[]={"BIS - Vanilla","BIS - Vanilla and ACE 3","BIS - Vanilla and ACE 3 (scroll wheel action)","ACE 3","ACE 3 (scroll wheel action)"};
 		default = 2;
 	};
 	class btc_p_rep { // Reputation at start:

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -239,6 +239,12 @@ class Params {
 		texts[]={""};
 		default = 0;
 	};
+	class btc_p_arsenalType { // Type of the arsenal:
+		title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE"]);
+		values[]={0,1,2,3,4};
+		texts[]={$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BIS,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BA,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BA_PLUS,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_ACE,$STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_ACE_PLUS}; //texts[]={"BIS - Vanilla","BIS - Vanilla and ACE 3","BIS - Vanilla und ACE 3 (scroll wheel action)","ACE 3","ACE 3 (scroll wheel action)"};
+		default = 2;
+	};
 	class btc_p_rep { // Reputation at start:
 		title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_OTHER_REPSTART"]);
 		values[]={0, 200, 500, 750};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -98,6 +98,6 @@ _action = ["fob_redeploy", localize "STR_BTC_HAM_ACTION_REDEPLOY_MAIN", "\A3\ui_
 if (btc_p_arsenalType < 3) then {
     btc_gear_object addAction [localize "STR_BTC_HAM_ACTION_ARSENAL_OPEN_BIS", "['Open',true] spawn BIS_fnc_arsenal;"];
 };
-if (btc_p_arsenalType isEqualTo 2 || btc_p_arsenalType isEqualTo 4) then {
+if (btc_p_arsenalType in [2, 4]) then {
     btc_gear_object addAction [localize "STR_BTC_HAM_ACTION_ARSENAL_OPEN_ACE", "[player, player, true] call ace_arsenal_fnc_openBox;"];
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -95,5 +95,9 @@ _action = ["fob_redeploy", localize "STR_BTC_HAM_ACTION_REDEPLOY_MAIN", "\A3\ui_
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
 
 //Arsenal
-btc_gear_object addAction [localize "STR_BTC_HAM_ACTION_ARSENAL_OPEN_ACE", "[player, player, true] call ace_arsenal_fnc_openBox;"];
-btc_gear_object addAction [localize "STR_BTC_HAM_ACTION_ARSENAL_OPEN_BIS", "['Open',true] spawn BIS_fnc_arsenal;"];
+if (btc_p_arsenalType < 3) then {
+    btc_gear_object addAction [localize "STR_BTC_HAM_ACTION_ARSENAL_OPEN_BIS", "['Open',true] spawn BIS_fnc_arsenal;"];
+};
+if (btc_p_arsenalType isEqualTo 2 || btc_p_arsenalType isEqualTo 4) then {
+    btc_gear_object addAction [localize "STR_BTC_HAM_ACTION_ARSENAL_OPEN_ACE", "[player, player, true] call ace_arsenal_fnc_openBox;"];
+};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -32,6 +32,8 @@ addMissionEventHandler ["BuildingChanged",btc_fnc_eh_buildingchanged];
 
 setTimeMultiplier btc_p_acctime;
 
+if (btc_p_arsenalType > 0) then {[btc_gear_object,true] call ace_arsenal_fnc_initBox;};
+
 {[_x,30,false] spawn btc_fnc_eh_veh_add_respawn;} forEach btc_helo;
 
 if (btc_p_side_mission_cycle) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -426,6 +426,30 @@
                 <Original>&lt;&lt; Other options &gt;&gt;</Original>
                 <German>&lt;&lt; Sonstige Einstellungen &gt;&gt;</German>
             </Key>
+            <Key ID="STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE">
+                <Original>Type of the arsenal:</Original>
+                <German>Art des Arsenals:</German>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BIS">
+                <Original>BIS - Vanilla</Original>
+                <German>BIS - Vanilla</German>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_ACE">
+                <Original>ACE 3</Original>
+                <German>ACE 3</German>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BA">
+                <Original>BIS - Vanilla and ACE 3</Original>
+                <German>BIS - Vanilla und ACE 3</German>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_ACE_PLUS">
+                <Original>ACE 3 (scroll wheel action)</Original>
+                <German>ACE 3 (Maus-Rad-Menü)</German>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BA_PLUS">
+                <Original>BIS - Vanilla und ACE 3 (scroll wheel action)</Original>
+                <German>BIS - Vanilla und ACE 3 (Maus-Rad-Menü)</German>
+            </Key>
             <Key ID="STR_BTC_HAM_PARAM_OTHER_REPSTART">
                 <Original>Reputation at start:</Original>
                 <German>Ansehen zu Beginn:</German>

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -447,7 +447,7 @@
                 <German>ACE 3 (Maus-Rad-Menü)</German>
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_OTHER_ARSENALTYPE_BA_PLUS">
-                <Original>BIS - Vanilla und ACE 3 (scroll wheel action)</Original>
+                <Original>BIS - Vanilla and ACE 3 (scroll wheel action)</Original>
                 <German>BIS - Vanilla und ACE 3 (Maus-Rad-Menü)</German>
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_OTHER_REPSTART">


### PR DESCRIPTION
- Add: Entry to the mission parameters to easily switch between BIS and/or ACE arsenal (@1kuemmel1).

**When merged this pull request will:**
- add an entry to the mission parameters, which allows the player (admin) to easily switch between the arsenal types (BIS/ACE/both)
- adds multiple options to switch (see screenshot below)

**Final test:**
- [x] local
- [x] server

**Screenshots**
![p_entry](https://user-images.githubusercontent.com/19553317/35771203-d61b499a-0928-11e8-9df4-d91b5df3a633.jpg)
![selection](https://user-images.githubusercontent.com/19553317/35771205-d7a4ba80-0928-11e8-873e-77272a762fe4.jpg)
