### PR TITLE
FIX: Can't fire after placing an object

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/place.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/place.sqf
@@ -61,5 +61,8 @@ btc_log_placing_obj setDir btc_log_placing_dir;
 		//remove mouse hint
 		call ace_interaction_fnc_hideMouseHint;
 
+		// remove drop action
+		[player, "DefaultAction", _actionEH, -1] call ace_common_fnc_removeActionEventHandler;
+
 	};
 }, 0.5, [_this, _actionEH, _place_EH_keydown]] call CBA_fnc_addPerFrameHandler;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/place.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/place.sqf
@@ -1,6 +1,6 @@
 btc_log_placing_obj = _this;
 
-[btc_log_placing_obj,player] remoteExec ["btc_fnc_set_owner", 2];
+[btc_log_placing_obj, player] remoteExec ["btc_fnc_set_owner", 2];
 
 hint composeText [
 	localize "STR_BTC_HAM_LOG_PLACE_HINT1", //Q/Z to raise/lower the object
@@ -18,13 +18,13 @@ btc_log_rotating_dir = 0;
 btc_log_ptich_dir = 0;
 
 //add action ACE
-[player, "DefaultAction", {true}, {btc_log_placing = false;}] call ace_common_fnc_addActionEventHandler;
+private _actionEH = [player, "DefaultAction", {true}, {btc_log_placing = false;}] call ace_common_fnc_addActionEventHandler;
 
 //show mouse hint for release
-[localize "STR_BTC_HAM_LOG_PLACE_RELEASE",""] call ace_interaction_fnc_showMouseHint; //Release
+[localize "STR_BTC_HAM_LOG_PLACE_RELEASE", ""] call ace_interaction_fnc_showMouseHint; //Release
 
 //add actions to keys
-btc_log_place_EH_keydown = (findDisplay 46) displayAddEventHandler ["KeyDown", btc_fnc_log_place_key_down];
+private _place_EH_keydown = (findDisplay 46) displayAddEventHandler ["KeyDown", btc_fnc_log_place_key_down];
 
 [player] call ace_weaponselect_fnc_putWeaponAway;
 player forceWalk true;
@@ -34,36 +34,32 @@ btc_log_placing_obj enableSimulation false;
 private _bbr = boundingBoxReal btc_log_placing_obj;
 private _c = boundingCenter btc_log_placing_obj;
 
-btc_log_placing_h = (abs ((_bbr select 0) select 2)) - (_c select 2);
-btc_log_placing_d = 1.5 + (abs (((_bbr select 1) select 1) - ((_bbr select 0) select 1)));
+btc_log_placing_h = abs((_bbr select 0) select 2) - (_c select 2);
+btc_log_placing_d = 1.5 + (abs(((_bbr select 1) select 1) - ((_bbr select 0) select 1)));
 
-btc_log_placing_obj attachTo [player,[0,(btc_log_placing_d),btc_log_placing_h]];
+btc_log_placing_obj attachTo [player,[0, btc_log_placing_d, btc_log_placing_h]];
 btc_log_placing_obj setDir btc_log_placing_dir;
-btc_log_placing_obj setDir btc_log_rotating_dir;
 
 [{
 	params ["_arguments", "_idPFH"];
-	if (!alive player || player getVariable ["ACE_isUnconscious",false] || !btc_log_placing) then {
+	if (!Alive player || player getVariable ["ACE_isUnconscious", false] || !btc_log_placing) then {
+		_arguments params ["_placing_obj", "_actionEH", "_place_EH_keydown"];
 
-		btc_log_placing_obj enableSimulation true;
-		detach btc_log_placing_obj;
+		//remove PFH
+		[_idPFH] call CBA_fnc_removePerFrameHandler;
 
-		//save to DB
-		[btc_log_placing_obj] call btc_fnc_db_saveObjectStatus;
-		//btc_log_obj_created pushBack btc_log_placing_obj;
+		_placing_obj enableSimulation true;
+		detach _placing_obj;
 
 		player forceWalk false;
 
 		btc_log_placing_obj = objNull;
-		(findDisplay 46) displayRemoveEventHandler ["KeyDown",btc_log_place_EH_keydown];
+		(findDisplay 46) displayRemoveEventHandler ["KeyDown", _place_EH_keydown];
 
 		hintSilent "";
 
 		//remove mouse hint
 		call ace_interaction_fnc_hideMouseHint;
 
-		//remove PFH
-		[_idPFH] call CBA_fnc_removePerFrameHandler;
-
 	};
-}, 0.5, [_this]] call CBA_fnc_addPerFrameHandler;
+}, 0.5, [_this, _actionEH, _place_EH_keydown]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
- Ignore changelog.

**When merged this pull request will:**
- Since https://github.com/Vdauphin/HeartsAndMinds/pull/448 you can't fire after placing an object until you respawn.
- the `btc_fnc_log_place` was not removing the `ace_common_fnc_addActionEventHandler` so player can't use his left bottom mouse any more.
- clean up (https://github.com/Vdauphin/HeartsAndMinds/pull/448/files?diff=unified#r167425203)

**Final test:**
- [x] local
- [x] server