### PR TITLE
FIX: Remove weapons when cache is destroyed

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/hd_cache.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/hd_cache.sqf
@@ -9,7 +9,7 @@ _explosive = (getNumber(configFile >> "cfgAmmo" >> _ammo >> "explosive") > 0);
 
 if (isNil {_cache getVariable "btc_hd_cache"} && {_explosive} && {_damage > 0.6}) then {
 	_cache setVariable ["btc_hd_cache",true];
-	{detach _x; _x setVariable ["no_cache",false];} forEach attachedObjects _cache;
+	{detach _x; deleteVehicle _x;} forEach attachedObjects _cache;
 	//Effects
 	private ["_pos","_marker"];
 	_pos = getposATL btc_cache_obj;


### PR DESCRIPTION
- FIX: Remove weapons when cache is destroyed (@Vdauphin).

**When merged this pull request will:**
- `deleteVehicle` on weapons when cache is destroyed.

**Final test:**
- [x] local
- [x] server