### PR TITLE
Add: missing preprocessFileLineNumbers part2

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/extended_PreInit_EH.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/extended_PreInit_EH.hpp
@@ -1,5 +1,5 @@
 class Extended_PreInit_EventHandlers {
     class btc_hearts_and_minds {
-        init = "call compile preprocessFile 'core\fnc\compile.sqf';";
+        init = "call compile preprocessFileLineNumbers 'core\fnc\compile.sqf';";
     };
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_player.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_player.sqf
@@ -1,5 +1,5 @@
 
-call compile preprocessFile "core\doc.sqf";
+call compile preprocessFileLineNumbers "core\doc.sqf";
 
 [] spawn {
 	waitUntil {!isNull player};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -1,12 +1,12 @@
-call compile preprocessFile "core\fnc\city\init.sqf";
+call compile preprocessFileLineNumbers "core\fnc\city\init.sqf";
 
 {[_x] spawn btc_fnc_task_create} foreach [0,1];
 
 if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db",worldName],false]}) then {
 	if (btc_version isEqualTo (profileNamespace getVariable [format ["btc_hm_%1_version",worldName],1.13])) then	{
-		call compile preprocessFile "core\fnc\db\load.sqf";
+		call compile preprocessFileLineNumbers "core\fnc\db\load.sqf";
 	} else {
-		call compile preprocessFile "core\fnc\db\load_old.sqf";
+		call compile preprocessFileLineNumbers "core\fnc\db\load_old.sqf";
 	};
 } else {
 	for "_i" from 1 to btc_hideout_n do {[] call btc_fnc_mil_create_hideout;};
@@ -15,9 +15,9 @@ if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db",worldNa
 	_date set [3, btc_p_time];
 	setDate _date;
 
-	call compile preprocessFile "core\fnc\cache\init.sqf";
+	call compile preprocessFileLineNumbers "core\fnc\cache\init.sqf";
 
-	[] spawn {{waitUntil {!isNull _x}; _x call btc_fnc_db_add_veh;} foreach btc_vehicles;};
+	{[{!isNull _this},{_this call btc_fnc_db_add_veh;}, _x] call CBA_fnc_waitUntilAndExecute;} forEach btc_vehicles;
 };
 
 call btc_fnc_db_autosave;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -3,11 +3,11 @@ call compile preprocessFileLineNumbers "core\fnc\city\init.sqf";
 {[_x] spawn btc_fnc_task_create} foreach [0,1];
 
 if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db",worldName],false]}) then {
-	if (btc_version isEqualTo (profileNamespace getVariable [format ["btc_hm_%1_version",worldName],1.13])) then	{
-		call compile preprocessFileLineNumbers "core\fnc\db\load.sqf";
-	} else {
-		call compile preprocessFileLineNumbers "core\fnc\db\load_old.sqf";
-	};
+    if (btc_version isEqualTo (profileNamespace getVariable [format ["btc_hm_%1_version",worldName],1.13])) then {
+        call compile preprocessFileLineNumbers "core\fnc\db\load.sqf";
+    } else {
+        call compile preprocessFileLineNumbers "core\fnc\db\load_old.sqf";
+    };
 } else {
     for "_i" from 1 to btc_hideout_n do {[] call btc_fnc_mil_create_hideout;};
 
@@ -15,9 +15,9 @@ if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db",worldNa
     _date set [3, btc_p_time];
     setDate _date;
 
-	call compile preprocessFileLineNumbers "core\fnc\cache\init.sqf";
+    call compile preprocessFileLineNumbers "core\fnc\cache\init.sqf";
 
-	{[{!isNull _this},{_this call btc_fnc_db_add_veh;}, _x] call CBA_fnc_waitUntilAndExecute;} forEach btc_vehicles;
+    {[{!isNull _this},{_this call btc_fnc_db_add_veh;}, _x] call CBA_fnc_waitUntilAndExecute;} forEach btc_vehicles;
 };
 
 call btc_fnc_db_autosave;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/init.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/init.sqf
@@ -6,15 +6,15 @@ call compile preprocessFileLineNumbers "core\def\mission.sqf";
 call compile preprocessFileLineNumbers "define_mod.sqf";
 
 if (isServer) then {
-		call compile preprocessFileLineNumbers "core\init_server.sqf";
+	call compile preprocessFileLineNumbers "core\init_server.sqf";
 };
 
 call compile preprocessFileLineNumbers "core\init_common.sqf";
 
 if (!isDedicated && hasInterface) then {
-		call compile preprocessFileLineNumbers "core\init_player.sqf";
+	call compile preprocessFileLineNumbers "core\init_player.sqf";
 };
 
 if (!isDedicated && !hasInterface) then {
-		call compile preprocessFileLineNumbers "core\init_headless.sqf";
+	call compile preprocessFileLineNumbers "core\init_headless.sqf";
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/init.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/init.sqf
@@ -2,19 +2,19 @@ enableSaving [false,false];
 
 if (hasInterface) then {btc_intro_done = [] spawn btc_fnc_intro;};
 
-call compile preprocessFile "core\def\mission.sqf";
-call compile preprocessFile "define_mod.sqf";
+call compile preprocessFileLineNumbers "core\def\mission.sqf";
+call compile preprocessFileLineNumbers "define_mod.sqf";
 
 if (isServer) then {
-	call compile preprocessFile "core\init_server.sqf";
+		call compile preprocessFileLineNumbers "core\init_server.sqf";
 };
 
-call compile preprocessFile "core\init_common.sqf";
+call compile preprocessFileLineNumbers "core\init_common.sqf";
 
 if (!isDedicated && hasInterface) then {
-	call compile preprocessFile "core\init_player.sqf";
+		call compile preprocessFileLineNumbers "core\init_player.sqf";
 };
 
 if (!isDedicated && !hasInterface) then {
-	call compile preprocessFile "core\init_headless.sqf";
+		call compile preprocessFileLineNumbers "core\init_headless.sqf";
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/init.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/init.sqf
@@ -6,15 +6,15 @@ call compile preprocessFileLineNumbers "core\def\mission.sqf";
 call compile preprocessFileLineNumbers "define_mod.sqf";
 
 if (isServer) then {
-	call compile preprocessFileLineNumbers "core\init_server.sqf";
+    call compile preprocessFileLineNumbers "core\init_server.sqf";
 };
 
 call compile preprocessFileLineNumbers "core\init_common.sqf";
 
 if (!isDedicated && hasInterface) then {
-	call compile preprocessFileLineNumbers "core\init_player.sqf";
+    call compile preprocessFileLineNumbers "core\init_player.sqf";
 };
 
 if (!isDedicated && !hasInterface) then {
-	call compile preprocessFileLineNumbers "core\init_headless.sqf";
+    call compile preprocessFileLineNumbers "core\init_headless.sqf";
 };


### PR DESCRIPTION
- Ignore changelog.

**When merged this pull request will:**
- similar like #422 
- replace `preprocessFile ` with `preprocessFileLineNumbers`
- replace `waitUntil ` with `CBA_fnc_waitUntilAndExecute` (just in [init_server.sqf](https://github.com/1kuemmel1/HeartsAndMinds/blob/f38f450852bc0f6b561d7958c2586b64a7897d02/%3DBTC%3Dco%4030_Hearts_and_Minds.Altis/core/init_server.sqf#L20))

**Final test:**
- [x] local
- [x] server