### PR TITLE
FIX: Debug marker have wrong color after restart for saved game

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_player_side.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_player_side.sqf
@@ -25,6 +25,7 @@ if (btc_debug) then    {//_debug
     _marker setMarkerAlpha 0.3;
     //_marker setmarkertype "mil_dot";
     if (_has_en) then {_marker setmarkercolor "colorRed";} else {_marker setmarkercolor "colorGreen";};
+    _city setVariable ["marker", _marker];
     //_marker setmarkeralpha 0.5;
     _marke = createmarker [format ["locn_%1",_id],_position];
     _marke setmarkertype "mil_dot";


### PR DESCRIPTION
- FIX: Wrong color for debug markers after restart for saved game (@Vdauphin).

**When merged this pull request will:**
- Initalize the "marker" variable on city in debug mode.

**Final test:**
- [x] local
- [x] server
