### PR TITLE
FIX: Animation fleeing

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/get_weapons.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/get_weapons.sqf
@@ -7,18 +7,12 @@ _units = [];
 if (count _this > 2) then {_units = _this select 2;} else {_units = _pos nearEntities [btc_civ_type_units, _range];};
 
 _units = _units select {side _x isEqualTo civilian};
-[[_units,_units apply {format ["amovp%1mstpsnonwnondnon",((animationState _x) select [5,3])]}], {
-    {
-        _x switchMove (_this select 1 select _foreachindex);
-    } forEach (_this select 0);
-}] remoteExec ["call", 0, false];
-
 {
     private ["_wp"];
     if (btc_debug_log) then    {diag_log format ["fnc_civ_get_weapons %1 - %2",_x,side _x];};
 
     _x call btc_fnc_rep_remove_eh;
-
+    [_x, "", 2] call ace_common_fnc_doAnimation;
     [_x] call btc_fnc_civ_add_weapons;
 
     [_x] joinSilent createGroup [btc_enemy_side, true];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/orders_behaviour.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/orders_behaviour.sqf
@@ -17,8 +17,8 @@ switch (_order) do {
     case 1 : {_unit setBehaviour selectRandom ["CARELESS", _behaviour]; doStop _unit;};
     case 2 : {
         doStop _unit;
+        [_unit, "", 2] call ace_common_fnc_doAnimation;
         _unit setUnitPos "DOWN";
-        [_unit, format ["AmovP%1MstpSnonWnonDnon_AmovPpneMstpSnonWnonDnon",((animationState _unit) select [5,3])], 1] call ace_common_fnc_doAnimation;
     };
     case 3 : {
         _unit setUnitPos "UP";


### PR DESCRIPTION
- FIX: Animation fleeing when 'get down' and getweapons (@Vdauphin).

**When merged this pull request will:**
- Reset the animation state when player give order get down and civilian getweapons
- no more weird animation where the civilian stand up take a virtual gun then seat down

**Final test:**
- [x] local
- [x] server