### PR TITLE
FIX: btc wreck deleted by clean_up function

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/clean_up.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/clean_up.sqf
@@ -1,16 +1,16 @@
+private _toRemove = ((allMissionObjects "groundweaponholder") select {!(_x getVariable ["no_cache", false])}) select {
+	private _obj = _x;
 
-private _toRemove = ((allMissionObjects "groundweaponholder") select {
-    private _obj = _x;
-
-    !(_x getVariable ["no_cache", false])}) select {({_x distance _obj < 150} count playableUnits) isEqualTo 0
+	playableUnits select {_x distance _obj < 150} isEqualTo []
 };
+
 
 _toRemove append (allDead select {
     private _dead = _x;
 
-    ({_x distance _dead < 300} count playableUnits) isEqualTo 0 && _dead getVariable ["btc_dont_delete", false]
+    (playableUnits select {_x distance _dead < 300}) isEqualTo [] && !(_dead getVariable ["btc_dont_delete", false])
 });
 
-_toRemove append (allGroups select {{alive _x} count units _x isEqualTo 0});
+_toRemove append (allGroups select {units _x select {alive _x} isEqualTo []});
 
 [_toRemove] call CBA_fnc_deleteEntity;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/clean_up.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/clean_up.sqf
@@ -1,7 +1,7 @@
 private _toRemove = ((allMissionObjects "groundweaponholder") select {!(_x getVariable ["no_cache", false])}) select {
-	private _obj = _x;
+    private _obj = _x;
 
-	playableUnits select {_x distance _obj < 150} isEqualTo []
+    playableUnits select {_x distance _obj < 150} isEqualTo []
 };
 
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/delete.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/delete.sqf
@@ -15,7 +15,7 @@ params [
     [{
         params ["_args", "_id"];
 
-        if ({_x distance _args < 1000} count playableUnits isEqualTo 0) then {
+        if (playableUnits select {_x distance _args < 1000} isEqualTo []) then {
             [_id] call CBA_fnc_removePerFrameHandler;
             [_args] call CBA_fnc_deleteEntity;
         };
@@ -27,7 +27,7 @@ params [
     [{
         params ["_args", "_id"];
 
-        if ({_x distance leader _args < 1000} count playableUnits isEqualTo 0) then {
+        if (playableUnits select {_x distance leader _args < 1000} isEqualTo []) then {
             [_id] call CBA_fnc_removePerFrameHandler;
             [_args] call CBA_fnc_deleteEntity;
         };


### PR DESCRIPTION
- Ignore change log.

**When merged this pull request will:**
- clean up remove destroyed vehicles because wrong condition
- remove `count` and prefer `select`

**Final test:**
- [x] local
- [x] server