### PR TITLE
FIX: Now btc_fnc_debug_message work outside fnc folder

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/debug/message.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/debug/message.sqf
@@ -6,5 +6,8 @@ params [
 _type params [["_systemchat", btc_debug], ["_rtp", btc_debug_log], ["_global", false]];
 
 private _startPosition = _folder find "fnc";
+if (_startPosition isEqualTo -1) then {
+    _startPosition = (_folder find worldName) + count worldName;
+};
 
 [_message, _folder select [_startPosition, (_folder find ".sqf") - _startPosition], _type] call CBA_fnc_debug;


### PR DESCRIPTION
- ignore change log.

**When merged this pull request will:**
- search for world name when fnc folder not found

**Final test:**
- [x] local
- [x] server