### PR TITLE
FIX: Most patrol around city spawn with only one unit

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -85,7 +85,7 @@ if !(_data_units isEqualTo []) then {
         //Find a better way to randomize city occupation
         private _n = random 3;
         private _groups = ceil ((1 + _n) * _ratio);
-        for "_i" from 1 to (_groups) do {[_city, _radius, random _ratio, random 1] call btc_fnc_mil_create_group;};
+        for "_i" from 1 to (_groups) do {[_city, _radius, 1 + random _ratio, random 1] call btc_fnc_mil_create_group;};
     };
 
     //Spawn civilians


### PR DESCRIPTION
- ignore change log.

**When merged this pull request will:**
- before create_croup generate at least 1 enemy at the beginning and then a second depending on the ratio.
- this new ratio fit more the new behavior

**Final test:**
- [x] local
- [x] server