### PR TITLE
FIX: Can't drop leaflets

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/add_leaflets.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/add_leaflets.sqf
@@ -4,8 +4,9 @@ params ["_player","_uav"];
 if !(_uav isKindOf "UAV_06_base_F") exitWith {};
 
 _uav addMagazine "1Rnd_Leaflets_West_F";
-if !("Bomb_Leaflets" in (_uav weaponsTurret [-1])) then {
+if !("Bomb_Leaflets" in (_uav weaponsTurret [[0, -1] select (_uav isKindOf "UAV_06_base_F")])) then {
     _uav addWeapon "Bomb_Leaflets";
+    _uav selectWeaponTurret ["Bomb_Leaflets", [[0, -1] select (_uav isKindOf "UAV_06_base_F")]];
 };
 if (needReload _uav == 1) then {reload _uav};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/add_leaflets.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/add_leaflets.sqf
@@ -6,8 +6,8 @@ if !(_uav isKindOf "UAV_06_base_F") exitWith {};
 _uav addMagazine "1Rnd_Leaflets_West_F";
 if !("Bomb_Leaflets" in (_uav weaponsTurret [[0, -1] select (_uav isKindOf "UAV_06_base_F")])) then {
     _uav addWeapon "Bomb_Leaflets";
-    _uav selectWeaponTurret ["Bomb_Leaflets", [[0, -1] select (_uav isKindOf "UAV_06_base_F")]];
 };
+_uav selectWeaponTurret ["Bomb_Leaflets", [[0, -1] select (_uav isKindOf "UAV_06_base_F")]];
 if (needReload _uav == 1) then {reload _uav};
 
 if ((_uav getVariable ["btc_leaflets_eh_added" , -1]) isEqualTo -1) then {


### PR DESCRIPTION
- FIX: Can't drop leaflets (@Vdauphin).

**When merged this pull request will:**
- H&M uses  https://community.bistudio.com/wiki/Arma_3_Leaflets#Mission_Usage
- For some reason the last update (tank DLC) remove the weapon (`"Bomb_Leaflets"`) on drone so player can't select leaflets.
- This fix force the drone to use leaflets (`selectWeaponTurret`).
- also fix this strange behavior discribed here: https://forums.bohemia.net/forums/topic/165948-mp-btc-hearts-and-minds/?page=41&tab=comments#comment-3295622

**Final test:**
- [x] local
- [x] server