### PR TITLE
Add: Use config and aiAmmoUsageFlags to dertermine btc_types

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/arsenal/ammoUsage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/arsenal/ammoUsage.sqf
@@ -1,0 +1,31 @@
+params [
+    ["_weapons", [], [[]]],
+    ["_aiAmmoUsageFlags", "256", [""]]
+];
+
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _cfgMagazines = configFile >> "CfgMagazines";
+private _cfgAmmo = configFile >> "CfgAmmo";
+
+_weapons select {
+    private _weapon = _x;
+    private _magazines = getArray (_cfgWeapons >> _weapon >> "magazines");
+    private _ammo = "";
+
+    if !(_magazines isEqualTo []) then {
+        _ammo = getText (_cfgMagazines >> _magazines select 0 >> "ammo");
+    };
+
+    private _aiAmmoUsage = getText (_cfgAmmo >> _ammo >> "aiAmmoUsageFlags");
+    if (_aiAmmoUsage isEqualTo "") then {
+        _aiAmmoUsage = str getNumber (_cfgAmmo >> _ammo >> "aiAmmoUsageFlags");
+    };
+
+    if (btc_debug_log) then {
+        if (_aiAmmoUsage isEqualTo "") then {
+            [format ["Weapons: %1 isAmmoUsage: %2", _weapons, _aiAmmoUsage], __FILE__, [false]] call btc_fnc_debug_message;
+        };
+    };
+
+    _aiAmmoUsage isEqualTo _aiAmmoUsageFlags;
+};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/arsenal/data.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/arsenal/data.sqf
@@ -1,5 +1,10 @@
-params ["_box", "_arsenalType", "_arsenalRestrict", "_arsenalData"];
-_arsenalData params [["_weapons", []], ["_magazines", []], ["_items", []], ["_backpacks", []]];
+params [
+    ["_box", objNull, [objNull]],
+    ["_arsenalType", 0, [0]],
+    ["_arsenalRestrict", 0, [0]],
+    ["_arsenalData", [], [[]]]
+];
+_arsenalData params [["_weapons", [], [[]]], ["_magazines", [], [[]]], ["_items", [], [[]]], ["_backpacks", [], [[]]]];
 
 //BIS Arsenal
 if (_arsenalType < 3) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/class.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/class.sqf
@@ -44,6 +44,6 @@ _factions = _factions apply {if !(isClass(_cfgFactionClasses >> _x)) then {
 
 //Final filter unwanted units type
 _type_units = _type_units select {((_x find "_Driver_") isEqualTo -1) && ((_x find "_base") isEqualTo -1) && ((_x find "_unarmed_") isEqualTo -1) && ((_x find "_VR_") isEqualTo -1) && ((_x find "_pilot_") isEqualTo -1)};
-_type_veh = _type_veh select {((_x find "UAV") isEqualTo -1) && ((_x find "UGV") isEqualTo -1) && ((_x find "_Kart_") isEqualTo -1)};
+_type_veh = _type_veh select {!(getNumber (_cfgVehicles >> _x >> "isUav") isEqualTo 1) && ((_x find "_Kart_") isEqualTo -1)};
 
 [_type_units, _type_boats, _type_veh]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -297,6 +297,7 @@ if (!isDedicated) then {
     btc_fnc_arsenal_garage = compile preprocessFileLineNumbers "core\fnc\arsenal\garage.sqf";
     btc_fnc_arsenal_loadout = compile preprocessFileLineNumbers "core\fnc\arsenal\loadout.sqf";
     btc_fnc_arsenal_trait = compile preprocessFileLineNumbers "core\fnc\arsenal\trait.sqf";
+    btc_fnc_arsenal_ammoUsage = compile preprocessFileLineNumbers "core\fnc\arsenal\ammoUsage.sqf";
 
     //TASK
     btc_fnc_task_create = compile preprocessFileLineNumbers "core\fnc\task\create.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -221,6 +221,9 @@ btc_fnc_log_paste = compile preprocessFileLineNumbers "core\fnc\log\paste.sqf";
 btc_fnc_mil_class = compile preprocessFileLineNumbers "core\fnc\mil\class.sqf";
 btc_fnc_mil_ammoUsage = compile preprocessFileLineNumbers "core\fnc\mil\ammoUsage.sqf";
 
+//ARSENAL
+btc_fnc_arsenal_ammoUsage = compile preprocessFileLineNumbers "core\fnc\arsenal\ammoUsage.sqf";
+
 //TASK
 btc_fnc_task_create = compile preprocessFileLineNumbers "core\fnc\task\create.sqf";
 btc_fnc_task_fail = compile preprocessFileLineNumbers "core\fnc\task\fail.sqf";
@@ -297,7 +300,6 @@ if (!isDedicated) then {
     btc_fnc_arsenal_garage = compile preprocessFileLineNumbers "core\fnc\arsenal\garage.sqf";
     btc_fnc_arsenal_loadout = compile preprocessFileLineNumbers "core\fnc\arsenal\loadout.sqf";
     btc_fnc_arsenal_trait = compile preprocessFileLineNumbers "core\fnc\arsenal\trait.sqf";
-    btc_fnc_arsenal_ammoUsage = compile preprocessFileLineNumbers "core\fnc\arsenal\ammoUsage.sqf";
 
     //TASK
     btc_fnc_task_create = compile preprocessFileLineNumbers "core\fnc\task\create.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/ammoUsage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/ammoUsage.sqf
@@ -1,25 +1,13 @@
-params ["_typeof_unit", ["_aiAmmoUsageFlags", "256"]];
+params [
+    ["_typeof_unit", "", [""]],
+    ["_aiAmmoUsageFlags", "256", [""]]
+];
 
-private _weapons = getArray(configFile >> "CfgVehicles" >> _typeof_unit >> "weapons");
+private _weapons = getArray (configFile >> "CfgVehicles" >> _typeof_unit >> "weapons");
 
-private _cfgWeapons = configFile >> "CfgWeapons";
-private _cfgMagazines = configFile >> "CfgMagazines";
-private _cfgAmmo = configFile >> "CfgAmmo";
-private _isAmmoUsage = _weapons apply {
-    private _weapon = _x;
-    private _magazines = getArray(_cfgWeapons >> _weapon >> "magazines");
-    private _ammo = "";
-    if !(_magazines isEqualTo []) then {
-        _ammo = getText(_cfgMagazines >> _magazines select 0 >> "ammo");
-    };
-    private _aiAmmoUsage = getText(_cfgAmmo >> _ammo >> "aiAmmoUsageFlags");
-    if (_aiAmmoUsage isEqualTo "") then {
-        _aiAmmoUsage = str getNumber(_cfgAmmo >> _ammo >> "aiAmmoUsageFlags");
-    };
-    _aiAmmoUsage isEqualTo _aiAmmoUsageFlags;
-};
+private _weapons_ammoUsage = [_weapons, _aiAmmoUsageFlags] call btc_fnc_arsenal_ammoUsage;
 if (btc_debug_log) then {
-    [format ["%1 Weapons: %2 isAmmoUsage: %3", _typeof_unit, _weapons, _isAmmoUsage], __FILE__, [false]] call btc_fnc_debug_message;
+    [format ["%1 Weapons: %2 isAmmoUsage: %3", _typeof_unit, _weapons, _weapons_ammoUsage], __FILE__, [false]] call btc_fnc_debug_message;
 };
 
-true in _isAmmoUsage;
+!(_weapons_ammoUsage isEqualTo [])

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/ammoUsage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/ammoUsage.sqf
@@ -2,16 +2,19 @@ params ["_typeof_unit", ["_aiAmmoUsageFlags", "256"]];
 
 private _weapons = getArray(configFile >> "CfgVehicles" >> _typeof_unit >> "weapons");
 
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _cfgMagazines = configFile >> "CfgMagazines";
+private _cfgAmmo = configFile >> "CfgAmmo";
 private _isAmmoUsage = _weapons apply {
     private _weapon = _x;
-    private _magazines = getArray(configFile >> "CfgWeapons" >> _weapon >> "magazines");
+    private _magazines = getArray(_cfgWeapons >> _weapon >> "magazines");
     private _ammo = "";
     if !(_magazines isEqualTo []) then {
-        _ammo = getText(configFile >> "CfgMagazines" >> _magazines select 0 >> "ammo");
+        _ammo = getText(_cfgMagazines >> _magazines select 0 >> "ammo");
     };
-    private _aiAmmoUsage = getText(configFile >> "CfgAmmo" >> _ammo >> "aiAmmoUsageFlags");
+    private _aiAmmoUsage = getText(_cfgAmmo >> _ammo >> "aiAmmoUsageFlags");
     if (_aiAmmoUsage isEqualTo "") then {
-        _aiAmmoUsage = str getNumber(configFile >> "CfgAmmo" >> _ammo >> "aiAmmoUsageFlags");
+        _aiAmmoUsage = str getNumber(_cfgAmmo >> _ammo >> "aiAmmoUsageFlags");
     };
     _aiAmmoUsage isEqualTo _aiAmmoUsageFlags;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/class.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/class.sqf
@@ -14,7 +14,7 @@ private _type_gl = [];
 //Get all vehicles
 private _cfgVehicles = configFile >> "CfgVehicles";
 private _allclass = ("(configName _x) isKindOf 'AllVehicles'" configClasses _cfgVehicles) apply {configName _x};
-_allclass = _allclass select {getNumber(_cfgVehicles >> _x >> "scope") isEqualTo 2};
+_allclass = _allclass select {getNumber (_cfgVehicles >> _x >> "scope") isEqualTo 2};
 
 //Check if faction existe
 private _cfgFactionClasses = configFile >> "CfgFactionClasses";
@@ -26,7 +26,7 @@ _factions = _factions apply {
     };
 };
 
-_enemy_side = [east, west, independent, civilian] select getNumber(_cfgFactionClasses >> _factions select 0 >> "side");
+_enemy_side = [east, west, independent, civilian] select getNumber (_cfgFactionClasses >> _factions select 0 >> "side");
 
 //Prevent selecting same side as player side
 if (_enemy_side isEqualTo btc_player_side) exitWith {
@@ -37,10 +37,10 @@ if (_enemy_side isEqualTo btc_player_side) exitWith {
     private _faction = _x;
 
     //Get all vehicles of the _faction selected
-    private _allclass_f = _allclass select {(toUpper getText(configFile >> "cfgvehicles" >> _x >> "faction")) isEqualTo _faction};
+    private _allclass_f = _allclass select {(toUpper getText (_cfgVehicles >> _x >> "faction")) isEqualTo _faction};
 
     //Units
-    _divers = _allclass_f select {!(((toLower _x) find "diver") isEqualTo -1)};
+    _divers = _allclass_f select {[_x, "64 + 32"] call btc_fnc_mil_ammoUsage};
     if (_divers isEqualTo []) then {
         _divers = if (_enemy_side isEqualTo east) then {
             ["O_diver_F", "O_diver_exp_F", "O_diver_TL_F"]
@@ -83,7 +83,7 @@ if !(_en_AA) then {
 };
 _type_units = _type_units select {((_x find "pilot_") isEqualTo -1) && ((_x find "_Pilot_") isEqualTo -1) && ((_x find "_Survivor_") isEqualTo -1) && ((_x find "_Story") isEqualTo -1) && ((_x find "_base") isEqualTo -1) && ((_x find "_unarmed_") isEqualTo -1) && ((_x find "_VR_") isEqualTo -1)};
 _type_crewmen = _type_units select 0;
-_type_motorized = (_type_motorized select {(_x find "UAV") isEqualTo -1}) select {(_x find "UGV") isEqualTo -1};
-_type_motorized_armed = (_type_motorized_armed select {(_x find "UAV") isEqualTo -1}) select {(_x find "UGV")  isEqualTo -1};
+_type_motorized = _type_motorized select {!(getNumber (_cfgVehicles >> _x >> "isUav") isEqualTo 1)};
+_type_motorized_armed = _type_motorized_armed select {!(getNumber (_cfgVehicles >> _x >> "isUav") isEqualTo 1)};
 
 [_enemy_side, _type_units, _type_divers, _type_crewmen, _type_boats, _type_motorized, _type_motorized_armed, _type_mg, _type_gl]


### PR DESCRIPTION
- Add: Use config and aiAmmoUsageFlags to dertermine btc_types (@Vdauphin).

**When merged this pull request will:**
- Use config to determine if is uav
- Use `btc_fnc_mil_ammoUsage` for diver

**Final test:**
- [x] local
- [x] server