### PR TITLE
Add: Unsheduled to deactivate city

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/arsenal/garage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/arsenal/garage.sqf
@@ -32,7 +32,7 @@ with uiNamespace do {
         private _dir = getDir _x;
         private _customization = [_x] call BIS_fnc_getVehicleCustomization;
 
-        [_x] call CBA_fnc_deleteEntity;
+        _x call CBA_fnc_deleteEntity;
         [_type, _pos, _dir, _customization] remoteExec ["btc_fnc_log_createVehicle", 2];
         [_type] remoteExec ["btc_fnc_eh_veh_init", -2];
     } forEach _veh_list;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/de_activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/de_activate.sqf
@@ -4,42 +4,49 @@ private _city = btc_city_all select _id;
 
 if !(_city getVariable ["active", false]) exitWith {};
 
-waitUntil {!(_city getVariable ["activating", false])};
+[{
+    params ["_city"];
 
-if (btc_debug) then {
-    hint ("DE-Activate " + str _this);
-};
+    !(_city getVariable ["activating", false])
+}, {
+    params ["_city", "_id"];
 
-//Save all and delete
-private _radius_x = _city getVariable ["RadiusX", 0];
-private _radius_y = _city getVariable ["RadiusY", 0];
-private _radius = _radius_x + _radius_y;
-
-private _has_en = _city getVariable ["occupied", false];
-
-if (_has_en) then {
-    private _trigger = _city getVariable ["trigger", objNull];
-    deleteVehicle _trigger;
-    _city setVariable ["trigger", objNull];
-};
-
-private _data_units = [];
-{
-    if (((leader _x) distance _city) < _radius && {side _x != btc_player_side} && !(_x getVariable ["no_cache", false])) then {
-        private _data_group = _x call btc_fnc_data_get_group;
-        _data_units pushBack _data_group;
-
-        if (btc_debug_log) then {
-            [format ["data units = %1", _data_units], __FILE__, [false]] call btc_fnc_debug_message;
-        };
+    if (btc_debug) then {
+        hint ("DE-Activate " + str _id);
     };
-} forEach allGroups;
 
-_city setVariable ["data_units", _data_units];
-_city setVariable ["active", false];
+    //Save all and delete
+    private _radius_x = _city getVariable ["RadiusX", 0];
+    private _radius_y = _city getVariable ["RadiusY", 0];
+    private _radius = _radius_x + _radius_y;
 
-if (!btc_hideout_cap_checking) then {
-    [] spawn btc_fnc_mil_check_cap;
-};
+    private _has_en = _city getVariable ["occupied", false];
 
-call btc_fnc_clean_up;
+    if (_has_en) then {
+        private _trigger = _city getVariable ["trigger", objNull];
+        deleteVehicle _trigger;
+        _city setVariable ["trigger", objNull];
+    };
+
+    private _data_units = [];
+    {
+        if (((leader _x) distance _city) < _radius && {side _x != btc_player_side} && !(_x getVariable ["no_cache", false])) then {
+            private _data_group = _x call btc_fnc_data_get_group;
+            _data_units pushBack _data_group;
+
+            if (btc_debug_log) then {
+                [format ["data units = %1", _data_units], __FILE__, [false]] call btc_fnc_debug_message;
+            };
+        };
+    } forEach allGroups;
+
+    _city setVariable ["data_units", _data_units];
+    _city setVariable ["active", false];
+
+    if (!btc_hideout_cap_checking) then {
+        [] call btc_fnc_mil_check_cap;
+    };
+
+    call btc_fnc_clean_up;
+
+}, [_city, _id]] call CBA_fnc_waitUntilAndExecute;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_player_side.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_player_side.sqf
@@ -3,7 +3,7 @@ params ["_position", "_radius_x", "_radius_y", "_city", "_has_en", "_name", "_ty
 private _trigger = createTrigger["EmptyDetector", _position];
 _trigger setTriggerArea[_radius_x + _radius_y + btc_city_radius, _radius_x + _radius_y + btc_city_radius, 0, false];
 _trigger setTriggerActivation["ANYPLAYER", "PRESENT", true];
-_trigger setTriggerStatements [btc_p_trigger, format ["[%1] spawn btc_fnc_city_activate", _id], format ["[%1] spawn btc_fnc_city_de_activate", _id]];
+_trigger setTriggerStatements [btc_p_trigger, format ["[%1] spawn btc_fnc_city_activate", _id], format ["[%1] call btc_fnc_city_de_activate", _id]];
 _city setVariable ["trigger_player_side", _trigger];
 
 if (btc_debug) then {//_debug

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/clean_up.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/clean_up.sqf
@@ -9,8 +9,7 @@ _toRemove append (allDead select {
 
     (playableUnits select {_x distance _dead < 300}) isEqualTo [] && !(_dead getVariable ["btc_dont_delete", false])
 });
-_toRemove call CBA_fnc_deleteEntity;
 
-{
-    deleteGroup _x;
-} forEach (allGroups select {units _x select {alive _x} isEqualTo []});
+_toRemove append (allGroups select {units _x select {alive _x} isEqualTo []});
+
+_toRemove call CBA_fnc_deleteEntity;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/clean_up.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/clean_up.sqf
@@ -4,13 +4,13 @@ private _toRemove = ((allMissionObjects "groundweaponholder") select {!(_x getVa
     playableUnits select {_x distance _obj < 150} isEqualTo []
 };
 
-
 _toRemove append (allDead select {
     private _dead = _x;
 
     (playableUnits select {_x distance _dead < 300}) isEqualTo [] && !(_dead getVariable ["btc_dont_delete", false])
 });
+_toRemove call CBA_fnc_deleteEntity;
 
-_toRemove append (allGroups select {units _x select {alive _x} isEqualTo []});
-
-[_toRemove] call CBA_fnc_deleteEntity;
+{
+    deleteGroup _x;
+} forEach (allGroups select {units _x select {alive _x} isEqualTo []});

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/delete.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/delete.sqf
@@ -29,8 +29,7 @@ params [
 
         if (playableUnits select {_x distance leader _args < 1000} isEqualTo []) then {
             [_id] call CBA_fnc_removePerFrameHandler;
-            (units _args) call CBA_fnc_deleteEntity;
-            deleteGroup _args;
+            _args call CBA_fnc_deleteEntity;
         };
     }, 5, _group] call CBA_fnc_addPerFrameHandler;
 } forEach _groups;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/delete.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/delete.sqf
@@ -17,7 +17,7 @@ params [
 
         if (playableUnits select {_x distance _args < 1000} isEqualTo []) then {
             [_id] call CBA_fnc_removePerFrameHandler;
-            [_args] call CBA_fnc_deleteEntity;
+            _args call CBA_fnc_deleteEntity;
         };
     }, 5, _object] call CBA_fnc_addPerFrameHandler;
 } forEach _objects;
@@ -29,7 +29,8 @@ params [
 
         if (playableUnits select {_x distance leader _args < 1000} isEqualTo []) then {
             [_id] call CBA_fnc_removePerFrameHandler;
-            [_args] call CBA_fnc_deleteEntity;
+            (units _args) call CBA_fnc_deleteEntity;
+            deleteGroup _args;
         };
     }, 5, _group] call CBA_fnc_addPerFrameHandler;
 } forEach _groups;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/data/get_group.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/data/get_group.sqf
@@ -50,7 +50,6 @@ if (_type_db isEqualTo 1) then {
     private _fuel = fuel _veh;
     _array_veh = [_type, _pos, _dir, _fuel];
 };
-[vehicle leader _group, units _group] call CBA_fnc_deleteEntity;
-deleteGroup _group;
+[vehicle leader _group, _group] call CBA_fnc_deleteEntity;
 
 [_type_db, _array_pos, _array_type, _side, _array_dam, _behaviour, [_index_wp, _array_wp], _array_veh]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/data/get_group.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/data/get_group.sqf
@@ -50,7 +50,7 @@ if (_type_db isEqualTo 1) then {
     private _fuel = fuel _veh;
     _array_veh = [_type, _pos, _dir, _fuel];
 };
-
-[vehicle leader _group, _group] call CBA_fnc_deleteEntity;
+[vehicle leader _group, units _group] call CBA_fnc_deleteEntity;
+deleteGroup _group;
 
 [_type_db, _array_pos, _array_type, _side, _array_dam, _behaviour, [_index_wp, _array_wp], _array_veh]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_active.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_active.sqf
@@ -31,7 +31,7 @@ _suicider addEventHandler ["Killed", {
     params ["_unit", "_killer"];
 
     if !(isPlayer _killer) then {
-        [attachedObjects _unit] call CBA_fnc_deleteEntity;
+        (attachedObjects _unit) call CBA_fnc_deleteEntity;
     };
 }];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/check_cap.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/check_cap.sqf
@@ -43,7 +43,9 @@ if (_cap_to isEqualTo []) exitWith {
 
     if (_closest getVariable ["initialized", false]) then {
         for "_i" from 0 to (2 + (round random 3)) do {
-            [_hd, _closest, 0] call btc_fnc_mil_send;
+            [{
+                _this call btc_fnc_mil_send;
+            }, [_hd, _closest, 0], _i * 2 + 1] call CBA_fnc_waitAndExecute;
         };
     } else {
         _closest setVariable ["occupied", true];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/checkpoint.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/checkpoint.sqf
@@ -78,7 +78,7 @@ for "_i" from 1 to (1 + round random 2) do {
         private _fx = "test_EmptyObjectForSmoke" createVehicle _pos;
         _fx setPos _pos;
         sleep 120;
-        [_fx] call CBA_fnc_deleteEntity;
+        _fx call CBA_fnc_deleteEntity;
     };
     _boxes pushBack _boxe;
 };


### PR DESCRIPTION
- Add: Unsheduled to deactivate city (@Vdauphin).


```sqf
[] spawn {
 for "_i" from 1 to 10 do {
  [str(_i)] remoteExec ["systemchat"];
  [102] call btc_fnc_city_activate;

  ["desactive"] remoteExec ["systemchat"];

  [102] call btc_fnc_city_de_activate;
  sleep 1;
 };
};

```
**When merged this pull request will:**
- This is a workaround to FIX dedicated server crash when CBA is deleting `group` until this is published https://github.com/CBATeam/CBA_A3/pull/940
- Also use unsheduled to deactivate city

**Final test:**
- [x] local
- [x] server