### PR TITLE
FIX: weapon holdersimulated isn't clean up

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/clean_up.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/clean_up.sqf
@@ -1,7 +1,7 @@
 {
     private _obj = _x;
     if (({_x distance _obj < 150} count playableUnits) == 0) then {deleteVehicle _obj};
-} foreach ((allMissionObjects "groundweaponholder") select {!(_x getVariable ["no_cache",false])});
+} foreach (((allMissionObjects "groundweaponholder") + (entities "WeaponHolderSimulated")) select {!(_x getVariable ["no_cache",false])});
 {
     private _dead = _x;
     if (({_x distance _dead < 300} count playableUnits) == 0 && isNil {_dead getVariable "btc_dont_delete"}) then {deleteVehicle _dead};


### PR DESCRIPTION
- FIX: Remove also weapon holder simulated (@Vdauphin).

**When merged this pull request will:**
- weapon holder simulated aren't clean up by the clean_up function

**Final test:**
- [x] local
- [x] server