### PR TITLE
FIX: When saved hideout are shifted along z

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
@@ -47,7 +47,8 @@ profileNamespace setVariable [format ["btc_hm_%1_cities", _name], _cities_status
 private _array_ho = [];
 {
     private _data = [];
-    _data pushBack (getPos _x);
+    (getPos _x) params ["_xx", "_yy"];
+    _data pushBack [_xx, _yy, 0];
     _data pushBack (_x getVariable ["id", 0]);
     _data pushBack (_x getVariable ["rinf_time", 0]);
     _data pushBack (_x getVariable ["cap_time", 0]);


### PR DESCRIPTION
- FIX: Floating hideouts (@Vdauphin).

**When merged this pull request will:**
- don't save the `z` axis as it is in the `btc_fnc_mil_create_hideout`

**Final test:**
- [x] local
- [x] server

**Screenshots**
![20180707165828_1](https://user-images.githubusercontent.com/14364400/42412902-aaeadf0e-8215-11e8-9616-8778c4e969a3.jpg)
