### PR TITLE
FIX: Hideout radius and city radius overlap

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_hideout.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_hideout.sqf
@@ -33,13 +33,8 @@ _city setPos _pos;
 _city setVariable ["ho_pos", _pos];
 if (btc_debug) then {deleteMarker format ["loc_%1", _id];};
 deleteVehicle (_city getVariable ["trigger_player_side", objNull]);
-private _radius_x = btc_hideouts_radius;
-private _radius_y = btc_hideouts_radius;
 
-[_pos, _radius_x, _radius_y, _city, _city getVariable "occupied", _city getVariable "name", _city getVariable "type", _city getVariable "id"] call btc_fnc_city_trigger_player_side;
-
-_city setVariable ["RadiusX", _radius_x];
-_city setVariable ["RadiusY", _radius_y];
+[_pos, btc_hideouts_radius, btc_hideouts_radius, _city, _city getVariable "occupied", _city getVariable "name", _city getVariable "type", _city getVariable "id"] call btc_fnc_city_trigger_player_side;
 
 private _hideout = [_pos] call btc_fnc_mil_create_hideout_composition;
 clearWeaponCargoGlobal _hideout;


### PR DESCRIPTION
- FIX: Hideout radius and city radius overlap resulting in a false liberated city/hideout (@Vdauphin).

**When merged this pull request will:**
- When a city near a hideout is desactivated, the city grab enemies from the hideout
- When a hideout near a city is desactivated, the hideout grab enemies from the city
- Resulting in a free city or hideout which isn't the case because when player activate the city/hideout containing enmies they spawn directly in the "free" city/hideout

**Final test:**
- [x] local
- [x] server