### PR TITLE
FIX: Remove DLC statics from logistic point menu

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -275,7 +275,14 @@ if (isServer) then {
     [
         //"Static"
         "B_Mortar_01_F"
-    ]  + (_allclass select {((_x isKindOf "StaticGrenadeLauncher") || (_x isKindOf "StaticMGWeapon")) && (getNumber(configfile >> "CfgVehicles" >> _x >> "side") isEqualTo ([east,west,independent,civilian] find btc_player_side))});
+    ]  + (_allclass select {(
+        _x isKindOf "GMG_TriPod" ||
+        _x isKindOf "StaticMortar" ||
+        _x isKindOf "HMG_01_base_F" ||
+        _x isKindOf "AA_01_base_F" ||
+        _x isKindOf "AT_01_base_F") && (
+        getNumber (configfile >> "CfgVehicles" >> _x >> "side") isEqualTo ([east, west, independent, civilian] find btc_player_side))
+    });
 
     _magazines_static = [];
     {


### PR DESCRIPTION
- FIX: Remove DLC statics from logistic point menu (@Vdauphin).

**When merged this pull request will:**
- use a more accurate filter to select only static HMG, GMG and Titan.

**Final test:**
- [x] local
- [x] server