### PR TITLE
FIX: Syntaxe error in params for set marker local and task create functions

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/set_markerTextLocal.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/set_markerTextLocal.sqf
@@ -1,7 +1,7 @@
 params [
     ["_marker", "", [""]],
     ["_text", "", [""]],
-    ["_arg", "", [""]]
+    ["_arg", "", ["", 0]]
 ];
 
 //check for localized text

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/task/create.sqf
@@ -1,6 +1,6 @@
 params [
     ["_task_id", "0", [0, ""]],
-    ["_destination", objNull, [objNull]],
+    ["_destination", objNull, [objNull, []]],
     ["_location", "", [""]]
 ];
 


### PR DESCRIPTION
- Ignore changelog.

**When merged this pull request will:**
- syntaxe error: could be a string or a number
-  task create error in params

**Final test:**
- [x] local
- [x] server