### PR TITLE
FIX: btc_fnc_delete using too much CBA_fnc_addPerFrameHandler

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/delete.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/delete.sqf
@@ -34,26 +34,4 @@ params [
     remoteExec ["", _x];
 } forEach _markers;
 
-{
-    private _object = _x;
-    [{
-        params ["_args", "_id"];
-
-        if (playableUnits inAreaArray [getPosWorld _args, 1000, 1000] isEqualTo []) then {
-            [_id] call CBA_fnc_removePerFrameHandler;
-            _args call CBA_fnc_deleteEntity;
-        };
-    }, 5, _object] call CBA_fnc_addPerFrameHandler;
-} forEach _objects;
-
-{
-    private _group = _x;
-    [{
-        params ["_args", "_id"];
-
-        if (playableUnits inAreaArray [getPosWorld leader _args, 1000, 1000] isEqualTo []) then {
-            [_id] call CBA_fnc_removePerFrameHandler;
-            _args call CBA_fnc_deleteEntity;
-        };
-    }, 5, _group] call CBA_fnc_addPerFrameHandler;
-} forEach _groups;
+[_objects + _groups] call btc_fnc_deleteEntities;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/deleteEntities.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/deleteEntities.sqf
@@ -41,6 +41,6 @@ Author:
     };
 
     if !(_entities isEqualTo []) exitWith {
-        [_entities, _playableUnits] call btc_fnc_deleteEntities;
+        _this call btc_fnc_deleteEntities;
     };
 }, _this, 1] call CBA_fnc_waitAndExecute;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/deleteEntities.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/deleteEntities.sqf
@@ -3,7 +3,7 @@
 Function: btc_fnc_deleteEntities
 
 Description:
-    This delete objects or groups when there are far from player.
+    This deletes objects or groups when they are far away from a player.
 
 Parameters:
     _entities - Entities deleted when _playableUnits are far. [Array]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/deleteEntities.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/deleteEntities.sqf
@@ -1,0 +1,46 @@
+
+/* ----------------------------------------------------------------------------
+Function: btc_fnc_deleteEntities
+
+Description:
+    This delete objects or groups when there are far from player.
+
+Parameters:
+    _entities - Entities deleted when _playableUnits are far. [Array]
+    _playableUnits - Objects needed to be far before entities are deleted. [Array]
+
+Returns:
+
+Examples:
+    (begin example)
+        _result = [_entities] call btc_fnc_deleteEntities;
+    (end)
+
+Author:
+    Vdauphin
+
+---------------------------------------------------------------------------- */
+
+[{
+    params [
+        ["_entities", [], [[]]],
+        ["_playableUnits", playableUnits, [[]]]
+    ];
+
+    private _entity = _entities deleteAt 0;
+    private _entity_obj = if (_entity isEqualType grpNull) then {
+        leader _entity
+    } else {
+        _entity
+    };
+
+    if (_playableUnits inAreaArray [getPosWorld _entity_obj, 1000, 1000] isEqualTo []) then {
+        _entity call CBA_fnc_deleteEntity;
+    } else {
+        _entities pushBack _entity;
+    };
+
+    if !(_entities isEqualTo []) exitWith {
+        [_entities, _playableUnits] call btc_fnc_deleteEntities;
+    };
+}, _this, 1] call CBA_fnc_waitAndExecute;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -18,6 +18,7 @@ if (isServer) then {
     btc_fnc_set_groupowner = compile preprocessFileLineNumbers "core\fnc\common\set_groupowner.sqf";
     btc_fnc_find_closecity = compile preprocessFileLineNumbers "core\fnc\common\find_closecity.sqf";
     btc_fnc_delete = compile preprocessFileLineNumbers "core\fnc\common\delete.sqf";
+    btc_fnc_deleteEntities = compile preprocessFileLineNumbers "core\fnc\common\deleteEntities.sqf";
     btc_fnc_final_phase = compile preprocessFileLineNumbers "core\fnc\common\final_phase.sqf";
     btc_fnc_findPosOutsideRock = compile preprocessFileLineNumbers "core\fnc\common\findposoutsiderock.sqf";
     btc_fnc_set_groupsowner = compile preprocessFileLineNumbers "core\fnc\common\set_groupsowner.sqf";


### PR DESCRIPTION
- Ignore changelog 

**When merged this pull request will:**
- The CBA_common_PFHhandles can be more than 9 999 999 long when the PFH is used too much.
- `[ count (CBA_common_PFHhandles select {_x isEqualType 0}), count CBA_common_PFHhandles]`

**Final test:**
- [x] local
- [x] server
