### PR TITLE
FIX: btc_fnc_ied_check using too much CBA_fnc_addPerFrameHandler

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -91,7 +91,6 @@ _city setVariable ["active", true];
 
 if !(_ieds isEqualTo []) then {
     private _ieds_data = _ieds apply {_x call btc_fnc_ied_create};
-    _city = btc_city_all select _id;
     [_city, _ieds_data] call btc_fnc_ied_check;
 };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -67,6 +67,7 @@ if (isServer) then {
     //IED
     btc_fnc_ied_boom = compile preprocessFileLineNumbers "core\fnc\ied\boom.sqf";
     btc_fnc_ied_check = compile preprocessFileLineNumbers "core\fnc\ied\check.sqf";
+    btc_fnc_ied_checkLoop = compile preprocessFileLineNumbers "core\fnc\ied\checkLoop.sqf";
     btc_fnc_ied_create = compile preprocessFileLineNumbers "core\fnc\ied\create.sqf";
     btc_fnc_ied_fired_near = compile preprocessFileLineNumbers "core\fnc\ied\fired_near.sqf";
     btc_fnc_ied_init_area = compile preprocessFileLineNumbers "core\fnc\ied\init_area.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/check.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/check.sqf
@@ -35,46 +35,4 @@ if (btc_debug_log) then {
 
 private _ieds_check = _ieds select {!((_x select 2) isEqualTo objNull)};
 
-[{
-    params ["_args", "_id"];
-    _args params ["_city", "_ieds", "_ieds_check"];
-
-    if (_city getVariable ["active", false]) then {
-        {
-            _x params ["_wreck", "_type", "_ied"];
-
-            if (!isNull _ied && {alive _ied}) then {
-                {
-                    if (side _x isEqualTo btc_player_side && {speed _x > 5 || vehicle _x != _x}) then {
-                        [_wreck, _ied] spawn btc_fnc_ied_boom;
-                    };
-                } forEach (_ied nearEntities ["allvehicles", 10]);
-            } else {
-                _ieds_check = _ieds_check - [_ied];
-            };
-        } forEach _ieds_check;
-    } else {
-        [_id] call CBA_fnc_removePerFrameHandler;
-
-        private _data = [];
-        {
-            _x params ["_wreck", "_type", "_ied"];
-
-            if (!isNull _wreck && {alive _wreck}) then {
-                _data pushBack [getPosATL _wreck, _type, getDir _wreck, !(_ied isEqualTo objNull)];
-
-                deleteVehicle _ied;
-                deleteVehicle _wreck;
-            };
-        } forEach _ieds;
-
-        _city setVariable ["ieds", _data];
-
-        if (btc_debug) then {
-            [format ["END CITY ID %1", _city getVariable "id"], __FILE__, [btc_debug, false]] call btc_fnc_debug_message;
-        };
-        if (btc_debug_log) then {
-            [format ["END CITY ID %1", _city getVariable "id"], __FILE__, [false]] call btc_fnc_debug_message;
-        };
-    };
-}, 1, [_city, _ieds, _ieds_check]] call CBA_fnc_addPerFrameHandler;
+[_city, _ieds, _ieds_check] call btc_fnc_ied_checkLoop;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/check.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/check.sqf
@@ -3,17 +3,17 @@
 Function: btc_fnc_ied_check
 
 Description:
-    Fill me when you edit me !
+    Contantly check if player is around by calling btc_fnc_ied_checkLoop. If yes, trigger the explosion.
 
 Parameters:
-    _city - [Object]
-    _ieds - [Array]
+    _city - City where IED has been created. [Object]
+    _ieds - All IED (even FACK IED). [Array]
 
 Returns:
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_ied_check;
+        [_city, _ieds] call btc_fnc_ied_check;
     (end)
 
 Author:

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/checkLoop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/checkLoop.sqf
@@ -1,0 +1,66 @@
+
+/* ----------------------------------------------------------------------------
+Function: btc_fnc_ied_checkLoop
+
+Description:
+    Loop over IED and check if player is around. If yes, trigger the explosion.
+
+Parameters:
+    _city - City where IED has been created. [Object]
+    _ieds - All IED (even FACK IED). [Array]
+    _ieds_check - Real IED triggering the explosion. [Array]
+
+Returns:
+
+Examples:
+    (begin example)
+       [_city, _ieds, _ieds_check] call btc_fnc_ied_checkLoop;
+    (end)
+
+Author:
+    Giallustio
+
+---------------------------------------------------------------------------- */
+
+[{
+    params ["_city", "_ieds", "_ieds_check"];
+
+    if (_city getVariable ["active", false]) exitWith {
+        {
+            _x params ["_wreck", "_type", "_ied"];
+
+            if (!isNull _ied && {alive _ied}) then {
+                {
+                    if (side _x isEqualTo btc_player_side && {speed _x > 5 || vehicle _x != _x}) then {
+                        [_wreck, _ied] spawn btc_fnc_ied_boom;
+                    };
+                } forEach (_ied nearEntities ["allvehicles", 10]);
+            } else {
+                _ieds_check = _ieds_check - [_ied];
+            };
+        } forEach _ieds_check;
+        [_city, _ieds, _ieds_check] call btc_fnc_ied_checkLoop;
+    };
+
+    private _data = [];
+    {
+        _x params ["_wreck", "_type", "_ied"];
+
+        if (!isNull _wreck && {alive _wreck}) then {
+            _data pushBack [getPosATL _wreck, _type, getDir _wreck, !(_ied isEqualTo objNull)];
+
+            deleteVehicle _ied;
+            deleteVehicle _wreck;
+        };
+    } forEach _ieds;
+
+    _city setVariable ["ieds", _data];
+
+    if (btc_debug) then {
+        [format ["END CITY ID %1", _city getVariable "id"], __FILE__, [btc_debug, false]] call btc_fnc_debug_message;
+    };
+    if (btc_debug_log) then {
+        [format ["END CITY ID %1", _city getVariable "id"], __FILE__, [false]] call btc_fnc_debug_message;
+    };
+
+}, _this, 1] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
- ignore changelog

**When merged this pull request will:**
- The CBA_common_PFHhandles can be more than 9 999 999 long when the PFH is used too much.

**Final test:**
- [x] local
- [x] server