### PR TITLE
FIX: btc_fnc_ied_fired_near use way too much CBA_fnc_addPerFrameHandler

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -132,6 +132,7 @@ if (isServer) then {
     btc_ied_suic_time = 900;
     btc_ied_suic_spawned = - btc_ied_suic_time;
     btc_ied_offset = [0, -0.03, -0.07] select _p_ied_spot;
+    btc_ied_list = [];
 
     //FOB
     btc_fobs = [[], []];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/create.sqf
@@ -44,7 +44,7 @@ if !(_active) exitWith {[_wreck, _type, objNull]};
 
 private _ied = createMine [selectRandom btc_type_ieds_ace, [_pos select 0, _pos select 1, btc_ied_offset], [], 2];
 _ied setVectorUp surfaceNormal _pos;
-//[_wreck, _ied] call btc_fnc_ied_fired_near;
+
 _pos params ["_xx", "_yy", "_zz"];
 _ied_list pushBack [_ied, _wreck, [_xx, _yy, _zz + 0.5]];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/create.sqf
@@ -3,19 +3,23 @@
 Function: btc_fnc_ied_create
 
 Description:
-    Fill me when you edit me !
+    Create wreck and add an IED when it is not a fake. True IED is added to the btc_ied_list to check if player is around.
 
 Parameters:
-    _pos - [Array]
-    _type - [String]
-    _dir - [Number]
-    _active - [Boolean]
+    _pos - Position of wreck. [Array]
+    _type - Shape name of the wreck. [String]
+    _dir - Direction of the wreck. [Number]
+    _active - Does the wreck has an IED around it. [Boolean]
+    _ied_list - Globale variable which store current active IED and delete them when there are removed. [Array]
 
 Returns:
+    _wreck - Simple object of the wreck. [Object]
+    _type - Shape name of the wreck. [String]
+    _ied - The IED object created. If fake, objNull is returned. [Object]
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_ied_create;
+        [_wreck, _type, _ied] = [[0,0,0], "a3\armor_f_beta\apc_tracked_01\apc_tracked_01_rcws_f.p3d", 90, true] call btc_fnc_ied_create;
     (end)
 
 Author:

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/create.sqf
@@ -27,7 +27,8 @@ params [
     ["_pos", [0, 0, 0], [[]]],
     ["_type", "", [""]],
     ["_dir", 0, [0]],
-    ["_active", false, [false]]
+    ["_active", false, [false]],
+    ["_ied_list", btc_ied_list, [[]]]
 ];
 
 if (btc_debug_log) then {
@@ -43,6 +44,8 @@ if !(_active) exitWith {[_wreck, _type, objNull]};
 
 private _ied = createMine [selectRandom btc_type_ieds_ace, [_pos select 0, _pos select 1, btc_ied_offset], [], 2];
 _ied setVectorUp surfaceNormal _pos;
-[_wreck, _ied] call btc_fnc_ied_fired_near;
+//[_wreck, _ied] call btc_fnc_ied_fired_near;
+_pos params ["_xx", "_yy", "_zz"];
+_ied_list pushBack [_ied, _wreck, [_xx, _yy, _zz + 0.5]];
 
 [_wreck, _type, _ied]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/fired_near.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/fired_near.sqf
@@ -3,17 +3,17 @@
 Function: btc_fnc_ied_fired_near
 
 Description:
-    Fill me when you edit me !
+    This check if bullets/grenade are trow around IED created during the mission and trigger them.
 
 Parameters:
-    _wreck - [Object]
-    _ied - [Object]
+    _ied_list - List of IED created in any city. [Array]
 
 Returns:
+    _PFH_id - Id of the CBA_fnc_addPerFrameHandler. [Number]
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_ied_fired_near;
+        _PFH_id = [btc_ied_list] call btc_fnc_ied_fired_near;
     (end)
 
 Author:
@@ -22,48 +22,50 @@ Author:
 ---------------------------------------------------------------------------- */
 
 params [
-    ["_wreck", objNull, [objNull]],
-    ["_ied", objNull, [objNull]]
+    ["_ied_list", btc_ied_list, [[]]]
 ];
 
-(getPos _ied) params ["_x", "_y", "_z"];
-private _pos = [_x, _y, _z + 0.5];
-private _range = 2;
+private _cfgAmmo = configFile >> "cfgAmmo";
 
-_array = [];
 [{
     params ["_args", "_id"];
-    _args params ["_ied", "_wreck", "_pos", "_range", "_array"];
+    _args params [
+        ["_ied_list", [], [[]]],
+        ["_cfgAmmo", configNull, [configNull]]
+    ];
 
-    if (Alive _ied && !isNull _ied) then {
-        private _list = _pos nearObjects ["Default", _range];
-        if !(_list isEqualTo []) then {
+    {
+        _x params ["_ied", "_wreck", "_pos"];
+
+        private _array = [];
+        if (alive _ied && !isNull _ied) then {
+            private _list = _pos nearObjects ["Default", 2];
             {
-                private _b = _x;
-                private _bullet = typeOf _b;
-                if (["SmokeShell", "FlareCore", "IRStrobeBase", "GrenadeHand_stone", "Smoke_120mm_AMOS_White", "TMR_R_DG32V_F"] findIf {_bullet isKindOf _x} != -1) exitWith {};
-                if (["TimeBombCore", "BombCore", "Grenade"] findIf {_bullet isKindOf _x} != -1) then {
-                    if !(_b in _array) then {
-                        _array pushBack _b;
-                        [{!Alive _b}, {
-                            params ["_wreck", "_ied"];
+                private _bullet = _x;
+                if !(["SmokeShell", "FlareCore", "IRStrobeBase", "GrenadeHand_stone", "Smoke_120mm_AMOS_White", "TMR_R_DG32V_F"] findIf {_bullet isKindOf _x} != -1) then {
+                    if (["TimeBombCore", "BombCore", "Grenade"] findIf {_bullet isKindOf _x} != -1) then {
+                        if !(_bullet in _array) then {
+                            _array pushBack _bullet;
+                            [{!alive (_this select 2)}, {
+                                params ["_wreck", "_ied"];
 
-                            if (Alive _ied) then {[_wreck, _ied] call btc_fnc_ied_boom;};
-                        }, [_wreck, _ied]] call CBA_fnc_waitUntilAndExecute;
-                    };
-                } else {
-                    private _cfgAmmo = configFile >> "cfgAmmo";
-                    private _explosive = getNumber(_cfgAmmo >> _bullet >> "explosive") > 0;
-                    private _caliber = getNumber(_cfgAmmo >> _bullet >> "caliber");
-                    if (_explosive || _caliber > 1.6) then {
-                        if (Alive _ied) then {
-                            [_wreck, _ied] call btc_fnc_ied_boom;
+                                if (alive _ied) then {[_wreck, _ied] call btc_fnc_ied_boom;};
+                            }, [_wreck, _ied, _bullet]] call CBA_fnc_waitUntilAndExecute;
+                        };
+                    } else {
+                        private _bullet_type = typeOf _bullet;
+                        private _explosive = getNumber (_cfgAmmo >> _bullet_type >> "explosive") > 0;
+                        private _caliber = getNumber (_cfgAmmo >> _bullet_type >> "caliber") > 1.6;
+                        if (_explosive || _caliber) then {
+                            if (alive _ied) then {
+                                [_wreck, _ied] call btc_fnc_ied_boom;
+                            };
                         };
                     };
                 };
             } forEach _list;
+        } else {
+            _ied_list deleteAt _forEachIndex;
         };
-    } else {
-        [_id] call CBA_fnc_removePerFrameHandler;
-    };
-}, 0.01, [_ied, _wreck, _pos, _range, _array]] call CBA_fnc_addPerFrameHandler;
+    } forEach _ied_list;
+}, 0.01, [_ied_list, _cfgAmmo]] call CBA_fnc_addPerFrameHandler;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -22,8 +22,8 @@ if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db", worldN
 };
 
 [] call btc_fnc_db_autosave;
-
 [] call btc_fnc_eh_server;
+[btc_ied_list] call btc_fnc_ied_fired_near;
 
 ["Initialize"] call BIS_fnc_dynamicGroups;
 


### PR DESCRIPTION
- Ignore changelog.

**When merged this pull request will:**
- The CBA_common_PFHhandles can be more than 9 999 999 long when the PFH is used too much.
- Now add IED in a global variable and remove them when there are deleted/destroyed.

**Final test:**
- [x] local
- [x] server