### PR TITLE
FIX: btc_fnc_ied_suicider/drone use way too much CBA_fnc_addPerFrameHandler

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -71,10 +71,13 @@ if (isServer) then {
     btc_fnc_ied_fired_near = compile preprocessFileLineNumbers "core\fnc\ied\fired_near.sqf";
     btc_fnc_ied_init_area = compile preprocessFileLineNumbers "core\fnc\ied\init_area.sqf";
     btc_fnc_ied_suicider_active = compile preprocessFileLineNumbers "core\fnc\ied\suicider_active.sqf";
+    btc_fnc_ied_suicider_activeLoop = compile preprocessFileLineNumbers "core\fnc\ied\suicider_activeLoop.sqf";
     btc_fnc_ied_suicider_create = compile preprocessFileLineNumbers "core\fnc\ied\suicider_create.sqf";
+    btc_fnc_ied_suiciderLoop = compile preprocessFileLineNumbers "core\fnc\ied\suiciderLoop.sqf";
     btc_fnc_ied_allahu_akbar = compile preprocessFileLineNumbers "core\fnc\ied\allahu_akbar.sqf";
     btc_fnc_ied_drone_active = compile preprocessFileLineNumbers "core\fnc\ied\drone_active.sqf";
     btc_fnc_ied_drone_create = compile preprocessFileLineNumbers "core\fnc\ied\drone_create.sqf";
+    btc_fnc_ied_droneLoop = compile preprocessFileLineNumbers "core\fnc\ied\droneLoop.sqf";
     btc_fnc_ied_drone_fire = compile preprocessFileLineNumbers "core\fnc\ied\drone_fire.sqf";
 
     //INFO

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/droneLoop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/droneLoop.sqf
@@ -1,0 +1,57 @@
+
+/* ----------------------------------------------------------------------------
+Function: btc_fnc_ied_droneLoop
+
+Description:
+    Search for soldier around the drone during a patrol. If soldier are in range, activate the drone.
+
+Parameters:
+    _driver_drone - Driver of the drone. [Object]
+    _rpos - Position where the drone patrol. [Array]
+    _area - Area of the patrol. [Array]
+    _trigger - Trigger of the drone when is active. [Group]
+
+Returns:
+
+Examples:
+    (begin example)
+        [_driver_drone, _rpos, _area, _trigger] call btc_fnc_ied_droneLoop;
+    (end)
+
+Author:
+    Vdauphin
+
+---------------------------------------------------------------------------- */
+
+[{
+    params ["_driver_drone", "_rpos", "_area", "_trigger"];
+
+    private _group = group _driver_drone;
+    if (alive _driver_drone && !isNull _driver_drone) then {
+        private _array = _driver_drone nearEntities ["SoldierWB", 200];
+        if (_array isEqualTo []) then {
+            if (waypoints _group isEqualTo []) then {
+                [_group, _rpos, _area, 4] call CBA_fnc_taskPatrol;
+                (vehicle _driver_drone) flyInHeight 10;
+                deleteVehicle (_trigger deleteAt 0);
+            };
+        } else {
+            if (_trigger isEqualTo []) then {
+                _trigger pushBack ([_driver_drone] call btc_fnc_ied_drone_active);
+            };
+
+            if (btc_debug) then {
+                hint format ["Distance with UAV IED : %1", (_array select 0) distance (vehicle _driver_drone)];
+            };
+            (vehicle _driver_drone) doMove (ASLtoAGL getPosASL (_array select 0));
+        };
+        _this call btc_fnc_ied_droneLoop;
+    } else {
+        deleteVehicle (_trigger deleteAt 0);
+        _group setVariable ["btc_ied_drone", false];
+
+        if (btc_debug_log) then {
+            [format ["_driver_drone = %1 POS %2 END LOOP", _driver_drone, getPos _driver_drone], __FILE__, [false]] call btc_fnc_debug_message;
+        };
+    };
+}, _this, 5] call CBA_fnc_waitAndExecute;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/drone_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/drone_create.sqf
@@ -8,8 +8,8 @@ Description:
 Parameters:
     _city - [Object]
     _area - [Number]
-    _rpos - [Array]
-    _group - [Group]
+    _rpos - Create the drone at this position. [Array]
+    _group - Group used for drone crew. [Group]
 
 Returns:
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/drone_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/drone_create.sqf
@@ -15,7 +15,7 @@ Returns:
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_ied_drone_create;
+        _leader = [allplayers select 0, 100] call btc_fnc_ied_drone_create;
     (end)
 
 Author:
@@ -47,37 +47,6 @@ _group setVariable ["btc_ied_drone", true];
 [_group, _rpos, _area, 4] call CBA_fnc_taskPatrol;
 _drone flyInHeight 10;
 
-//Main check
-[{
-    params ["_args", "_id"];
-    _args params ["_driver_drone", "_rpos", "_area", "_trigger"];
-
-    private _group = group _driver_drone;
-    if (Alive _driver_drone && !isNull _driver_drone) then {
-        private _array = _driver_drone nearEntities ["SoldierWB", 200];
-        if (_array isEqualTo []) then {
-            if (waypoints _group isEqualTo []) then {
-                [_group, _rpos, _area, 4] call CBA_fnc_taskPatrol;
-                (vehicle _driver_drone) flyInHeight 10;
-                deleteVehicle (_trigger deleteAt 0);
-            };
-        } else {
-            if (_trigger isEqualTo []) then {
-                _trigger pushBack ([_driver_drone] call btc_fnc_ied_drone_active);
-            };
-            if (btc_debug) then {
-                hint format ["Distance with UAV IED : %1", (_array select 0) distance (vehicle _driver_drone)];
-            };
-            (vehicle _driver_drone) doMove (ASLtoAGL getPosASL (_array select 0));
-        };
-    } else {
-        [_id] call CBA_fnc_removePerFrameHandler;
-        deleteVehicle (_trigger deleteAt 0);
-        _group setVariable ["btc_ied_drone", false];
-        if (btc_debug_log) then {
-            [format ["_driver_drone = %1 POS %2 END LOOP", _driver_drone, getPos _driver_drone], __FILE__, [false]] call btc_fnc_debug_message;
-        };
-    };
-}, 5, [driver _drone, _rpos, _area, []]] call CBA_fnc_addPerFrameHandler;
+[driver _drone, _rpos, _area, []] call btc_fnc_ied_droneLoop;
 
 leader _group

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/drone_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/drone_create.sqf
@@ -3,15 +3,16 @@
 Function: btc_fnc_ied_drone_create
 
 Description:
-    Fill me when you edit me !
+    Create a drone in a city under a random area.
 
 Parameters:
-    _city - [Object]
-    _area - [Number]
+    _city - City where the drone is created. [Object]
+    _area - Area around the city where the drone is created randomly. [Number]
     _rpos - Create the drone at this position. [Array]
     _group - Group used for drone crew. [Group]
 
 Returns:
+    _leader - return the leader of the group. [Object]
 
 Examples:
     (begin example)

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suiciderLoop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suiciderLoop.sqf
@@ -1,0 +1,32 @@
+
+/* ----------------------------------------------------------------------------
+Function: btc_fnc_ied_suiciderLoop
+
+Description:
+    Search for soldier around and when found, activate the suicider.
+
+Parameters:
+    _suicider - Suicider created. [Object]
+
+Returns:
+
+Examples:
+    (begin example)
+        [_suicider] call btc_fnc_ied_suiciderLoop;
+    (end)
+
+Author:
+    Giallustio
+
+---------------------------------------------------------------------------- */
+
+[{
+    params ["_suicider"];
+
+    if (alive _suicider && !isNull _suicider) then {
+        if !((_suicider nearEntities ["SoldierWB", 25]) isEqualTo []) exitWith {
+            _suicider call btc_fnc_ied_suicider_active;
+        };
+        _this call btc_fnc_ied_suiciderLoop;
+    };
+}, _this, 5] call CBA_fnc_waitAndExecute;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_active.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_active.sqf
@@ -12,7 +12,7 @@ Returns:
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_ied_suicider_active;
+        [_suicider] call btc_fnc_ied_suicider_active;
     (end)
 
 Author:

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_active.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_active.sqf
@@ -3,10 +3,10 @@
 Function: btc_fnc_ied_suicider_active
 
 Description:
-    Fill me when you edit me !
+    Activate the suicider by adding explosive charge around his pelvis and force suicider to move in the direction of soldier.
 
 Parameters:
-    _suicider - [Object]
+    _suicider - Suicider created. [Object]
 
 Returns:
 
@@ -66,21 +66,4 @@ if (btc_debug_log) then {
     [format ["_suicider = %1 POS %2 START LOOP", _suicider, getPos _suicider], __FILE__, [false]] call btc_fnc_debug_message;
 };
 
-[{
-    params ["_args", "_id"];
-    _args params ["_suicider", "_trigger"];
-
-    if (Alive _suicider) then {
-        private _array = _suicider nearEntities ["SoldierWB", 30];
-        if !(_array isEqualTo []) then {
-            _suicider doMove (position (_array select 0));
-        };
-    } else {
-        [_id] call CBA_fnc_removePerFrameHandler;
-        deleteVehicle _trigger;
-        group _suicider setVariable ["suicider", false];
-        if (btc_debug_log) then {
-            [format ["_suicider = %1 POS %2 END LOOP", _suicider, getPos _suicider], __FILE__, [false]] call btc_fnc_debug_message;
-        };
-    };
-}, 0.5, [_suicider, _trigger]] call CBA_fnc_addPerFrameHandler;
+[_suicider, _trigger] call btc_fnc_ied_suicider_activeLoop;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_activeLoop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_activeLoop.sqf
@@ -1,0 +1,41 @@
+
+/* ----------------------------------------------------------------------------
+Function: btc_fnc_ied_suicider_activeLoop
+
+Description:
+    Detect and force the suicider to run in the direction of the soldier nearby.
+
+Parameters:
+    _suicider - Suicider. [Object]
+    _trigger - Trigger triggring the suicider explosion. [Object]
+
+Returns:
+
+Examples:
+    (begin example)
+        [_suicider, _trigger] call btc_fnc_ied_suicider_activeLoop;
+    (end)
+
+Author:
+    Giallustio
+
+---------------------------------------------------------------------------- */
+
+[{
+    params ["_suicider", "_trigger"];
+
+    if (alive _suicider) then {
+        private _array = _suicider nearEntities ["SoldierWB", 30];
+        if !(_array isEqualTo []) then {
+            _suicider doMove (position (_array select 0));
+        };
+        _this call btc_fnc_ied_suicider_activeLoop;
+    } else {
+        deleteVehicle _trigger;
+        group _suicider setVariable ["suicider", false];
+
+        if (btc_debug_log) then {
+            [format ["_suicider = %1 POS %2 END LOOP", _suicider, getPos _suicider], __FILE__, [false]] call btc_fnc_debug_message;
+        };
+    };
+}, _this, 0.5] call CBA_fnc_waitAndExecute;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_create.sqf
@@ -7,7 +7,7 @@ Description:
 
 Parameters:
     _city - City where the suicider is created. [Object]
-    _area - Area where the suicider is created randomly. [Number]
+    _area - Area around the city the suicider is created randomly. [Number]
 
 Returns:
     _suicider - Created suicider. [Object]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_create.sqf
@@ -3,17 +3,18 @@
 Function: btc_fnc_ied_suicider_create
 
 Description:
-    Fill me when you edit me !
+    Create a suicider in a city under a random area.
 
 Parameters:
-    _city - [Object]
-    _area - [Number]
+    _city - City where the suicider is created. [Object]
+    _area - Area where the suicider is created randomly. [Number]
 
 Returns:
+    _suicider - Created suicider. [Object]
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_ied_suicider_create;
+        _suicider = [allplayers select 0, 100] call btc_fnc_ied_suicider_create;
     (end)
 
 Author:
@@ -42,19 +43,6 @@ _group setVariable ["suicider", true];
 
 _suicider call btc_fnc_civ_unit_create;
 
-//Main check
-[{
-    params ["_args", "_id"];
-    _args params ["_suicider"];
-
-    if (Alive _suicider && !isNull _suicider) then {
-        if !((getPos _suicider nearEntities ["SoldierWB", 25]) isEqualTo []) then {
-            [_id] call CBA_fnc_removePerFrameHandler;
-            _suicider call btc_fnc_ied_suicider_active;
-        };
-    } else {
-        [_id] call CBA_fnc_removePerFrameHandler;
-    };
-}, 5, [_suicider]] call CBA_fnc_addPerFrameHandler;
+[_suicider] call btc_fnc_ied_suiciderLoop;
 
 _suicider


### PR DESCRIPTION
- Ignore change log.

**When merged this pull request will:**
- The CBA_common_PFHhandles can be more than 9 999 999 long when the PFH is used too much.

**Final test:**
- [x] local
- [x] server