### PR TITLE
Add: Mission parameter to change probability of a city to be free

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -45,6 +45,7 @@ private _p_skill = [
 ];
 
 //<< Spawn options >>
+btc_p_is_free_prob = ("btc_p_is_free_prob" call BIS_fnc_getParamValue)/100;
 btc_p_mil_group_ratio = ("btc_p_mil_group_ratio" call BIS_fnc_getParamValue)/100;
 btc_p_civ_group_ratio = ("btc_p_civ_group_ratio" call BIS_fnc_getParamValue)/100;
 private _wp_house_probability = ("btc_p_wp_house_probability" call BIS_fnc_getParamValue)/100;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -71,6 +71,12 @@ class Params {
         texts[]={""};
         default = 0;
     };
+    class btc_p_is_free_prob { // Probability for a city to be free:
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_ENEMY_DENSITY"]);
+        values[]={0,10,20,30,40,45,50,60,70,80,90,100};
+        texts[]={"0%","10%","20%","30%","40%","45%","50%","60%","70%","80%","90%","100%"};
+        default = 45;
+    };
     class btc_p_mil_group_ratio { // Enemy density:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_ENEMY_DENSITY"]);
         values[]={0,10,20,30,40,50,60,70,80,90,100};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -72,7 +72,7 @@ class Params {
         default = 0;
     };
     class btc_p_is_free_prob { // Probability for a city to be free:
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_ENEMY_DENSITY"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_ISFREE_PROB"]);
         values[]={0,10,20,30,40,45,50,60,70,80,90,100};
         texts[]={"0%","10%","20%","30%","40%","45%","50%","60%","70%","80%","90%","100%"};
         default = 45;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/init.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/init.sqf
@@ -6,6 +6,7 @@ Description:
     Create cities all over the map and store those properties.
 
 Parameters:
+    _is_free_probability - Probability for a city to have military. [Number]
 
 Returns:
 
@@ -18,6 +19,10 @@ Author:
     Giallustio
 
 ---------------------------------------------------------------------------- */
+
+params [
+    ["_is_free_probability", btc_p_is_free_prob, [0]]
+];
 
 private _locations = configfile >> "cfgworlds" >> worldname >> "names";
 
@@ -62,7 +67,7 @@ for "_i" from 0 to (count _locations - 1) do {
         if ((getMarkerPos "YOUR_MARKER_AREA") inArea [_position, 500, 500, 0, false]) exitWith {};
         */
 
-        [_position, _type, _name, _radius_x, _radius_y, random 1 > 0.45] call btc_fnc_city_create;
+        [_position, _type, _name, _radius_x, _radius_y, random 1 > _is_free_probability] call btc_fnc_city_create;
     };
 };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -309,6 +309,9 @@
                 <Original>&lt;&lt; Spawn options &gt;&gt;</Original>
                 <German>Spawn Einstellungen:</German>
             </Key>
+            <Key ID="STR_BTC_HAM_PARAM_SPWAN_ISFREE_PROB">
+                <Original>Probability for a city to be free:</Original>
+            </Key>
             <Key ID="STR_BTC_HAM_PARAM_SPWAN_ENEMY_DENSITY">
                 <Original>Enemy density:</Original>
                 <German>Feinddichte:</German>

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -311,6 +311,7 @@
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_SPWAN_ISFREE_PROB">
                 <Original>Probability for a city to be free:</Original>
+                <German>Wahrscheinlichkeit, dass eine Stadt unbesetzt ist:</German>
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_SPWAN_ENEMY_DENSITY">
                 <Original>Enemy density:</Original>


### PR DESCRIPTION
- Add: Mission parameter to change probability of a city to be free (@Vdauphin).

**When merged this pull request will:**
-  Add: Mission parameter to change probability of a city to be free

- [x] add german when https://github.com/Vdauphin/HeartsAndMinds/pull/632 merged

**Final test:**
- [x] local
- [x] server
