### PR TITLE
FIX: ACE vehicles' parameters not saved

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -3,16 +3,16 @@
 Function: btc_fnc_db_load
 
 Description:
-    Fill me when you edit me !
+    Load database from profileNamespace depends one worldname
 
 Parameters:
-    _name - [String]
+    _name - Name of the saved game. [String]
 
 Returns:
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_db_load;
+        ["Altis"] call btc_fnc_db_load;
     (end)
 
 Author:

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -117,7 +117,20 @@ private _vehs = profileNamespace getVariable [format ["btc_hm_%1_vehs", _name], 
     params ["_vehs", "_global_reputation"];
 
     {
-        _x params ["_veh_type", "_veh_pos", "_veh_dir", "_veh_fuel", "_veh_AllHitPointsDamage", "_veh_cargo", "_veh_cont", "_customization"];
+        _x params [
+            "_veh_type",
+            "_veh_pos",
+            "_veh_dir",
+            "_veh_fuel",
+            "_veh_AllHitPointsDamage",
+            "_veh_cargo",
+            "_veh_cont",
+            "_customization",
+            ["_isMedicalVehicle", false, [true]],
+            ["_isRepairVehicle", false, [true]],
+            ["_fuelSource", [], [[]]],
+            ["_pylons", [], [[]]]
+        ];
 
         if (btc_debug_log) then {
             [format ["_veh = %1", _x], __FILE__, [false]] call btc_fnc_debug_message;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -126,8 +126,8 @@ private _vehs = profileNamespace getVariable [format ["btc_hm_%1_vehs", _name], 
             "_veh_cargo",
             "_veh_cont",
             "_customization",
-            ["_isMedicalVehicle", false, [true]],
-            ["_isRepairVehicle", false, [true]],
+            ["_isMedicalVehicle", false, [false]],
+            ["_isRepairVehicle", false, [false]],
             ["_fuelSource", [], [[]]],
             ["_pylons", [], [[]]]
         ];
@@ -136,7 +136,7 @@ private _vehs = profileNamespace getVariable [format ["btc_hm_%1_vehs", _name], 
             [format ["_veh = %1", _x], __FILE__, [false]] call btc_fnc_debug_message;
         };
 
-        private _veh = [_veh_type, _veh_pos, _veh_dir, _customization] call btc_fnc_log_createVehicle;
+        private _veh = [_veh_type, _veh_pos, _veh_dir, _customization, _isMedicalVehicle, _isRepairVehicle, _fuelSource, _pylons] call btc_fnc_log_createVehicle;
         if ((getPos _veh) select 2 < 0) then {_veh setVectorUp surfaceNormal position _veh;};
         _veh setFuel _veh_fuel;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
@@ -3,16 +3,16 @@
 Function: btc_fnc_db_save
 
 Description:
-    Fill me when you edit me !
+    Save the current game into profileNamespace.
 
 Parameters:
-    _name - [String]
+    _name - Name of the game saved. [String]
 
 Returns:
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_db_save;
+        ["Altis"] call btc_fnc_db_save;
     (end)
 
 Author:

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
@@ -149,6 +149,13 @@ private _array_veh = [];
     private _cont = [getWeaponCargo _x, getMagazineCargo _x, getItemCargo _x];
     _data pushBack _cont;
     _data pushBack ([_x] call BIS_fnc_getVehicleCustomization);
+    _data pushBack ([_x] call ace_medical_fnc_isMedicalVehicle);
+    _data pushBack ([_x] call ace_repair_fnc_isRepairVehicle);
+    _data pushBack ([
+        [_x] call ace_refuel_fnc_getFuel,
+        _x getVariable ["ace_refuel_hooks", []]
+    ]);
+    _data pushBack (getPylonMagazines _x);
     _array_veh pushBack _data;
     if (btc_debug_log) then {
         [format ["VEH %1 DATA %2", _x, _data], __FILE__, [false]] call btc_fnc_debug_message;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
@@ -27,13 +27,45 @@ params [
     ["_type", "", [""]],
     ["_pos", [0, 0, 0], [[]]],
     ["_dir", 0, [0]],
-    ["_customization", [false, false], [[]]]
+    ["_customization", [false, false], [[]]],
+    ["_isMedicalVehicle", false, [true]],
+    ["_isRepairVehicle", false, [true]],
+    ["_fuelSource", [], [[]]],
+    ["_pylons", [], [[]]]
 ];
 
 private _veh  = createVehicle [_type, ASLToATL _pos, [], 0, "CAN_COLLIDE"];
 _veh setDir _dir;
 _veh setPosASL _pos;
 [_veh, _customization select 0, _customization select 1] call BIS_fnc_initVehicle;
+if (_isMedicalVehicle && {!([_veh] call ace_medical_fnc_isMedicalVehicle)}) then {
+    _veh setVariable ["ACE_isMedicalVehicle", _isMedicalVehicle, true];
+};
+if (_isRepairVehicle && {!([_veh] call ace_repair_fnc_isRepairVehicle)}) then {
+    _veh setVariable ["ACE_isRepairVehicle", _isRepairVehicle, true];
+};
+if !(_fuelSource isEqualTo []) then {
+    _fuelSource params [
+        ["_source", objNull, [objNull]],
+        ["_fuelCargo", 0, [0]],
+        ["_hooks", nil, [[]]]
+    ];
+    [_source, _fuelCargo, _hooks] call ace_refuel_fnc_makeSource;
+};
+if !(_pylons isEqualTo []) then {
+    _fuelSource params [
+        ["_source", objNull, [objNull]],
+        ["_fuelCargo", 0, [0]],
+        ["_hooks", nil, [[]]]
+    ];
+    private _pylonPaths = (configProperties [configFile >> "CfgVehicles" >> typeOf _veh >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"]) apply {getArray (_x >> "turret")};
+    {
+        _veh removeWeaponGlobal getText (configFile >> "CfgMagazines" >> _x >> "pylonWeapon")
+    } forEach getPylonMagazines _veh;
+    {
+        _veh setPylonLoadOut [_forEachIndex + 1, _x, true, _pylonPaths select _forEachIndex]
+    } forEach _pylons;
+};
 
 _veh setVariable ["btc_dont_delete", true];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
@@ -49,7 +49,7 @@ if !(_fuelSource isEqualTo []) then {
         ["_fuelCargo", 0, [0]],
         ["_hooks", nil, [[]]]
     ];
-    if ((!isNil "_hooks") && {_hooks isEqualTo (_veh getVariable ["ace_refuel_hooks", []])}) then {
+    if ((!isNil "_hooks") && {!(_hooks isEqualTo (_veh getVariable ["ace_refuel_hooks", []]))}) then {
         [_veh, _fuelCargo, _hooks] call ace_refuel_fnc_makeSource;
     } else {
         if (_fuelCargo != [_veh] call ace_refuel_fnc_getFuel) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
@@ -3,19 +3,23 @@
 Function: btc_fnc_log_createVehicle
 
 Description:
-    Fill me when you edit me !
+    Creates an empty object of given classname type.
 
 Parameters:
-    _type - [String]
-    _pos - [Array]
-    _dir - [Number]
-    _customization - [Array]
+    _type - Vehicle className. [String]
+    _pos -  Desired placement position. If the exact position is occupied, nearest empty position is used. [Array]
+    _dir - Desired direction. [Number]
+    _customization - Customized appearance [Array]
+    _isMedicalVehicle - Set the ACE parameter is a medical vehicle. [Boolean]
+    _isRepairVehicle - Set the ACE parameter is a repair vehicle. [Boolean]
+    _fuelSource - Define the ACE cargo fuel source. [Array]
+    _pylons - Set pylon loadout. [Array]
 
 Returns:
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_log_createVehicle;
+        _veh = ["vehicle_class_name", getPos player] call btc_fnc_log_createVehicle;
     (end)
 
 Author:

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/createVehicle.sqf
@@ -39,25 +39,25 @@ _veh setDir _dir;
 _veh setPosASL _pos;
 [_veh, _customization select 0, _customization select 1] call BIS_fnc_initVehicle;
 if (_isMedicalVehicle && {!([_veh] call ace_medical_fnc_isMedicalVehicle)}) then {
-    _veh setVariable ["ACE_isMedicalVehicle", _isMedicalVehicle, true];
+    _veh setVariable ["ace_medical_medicclass", 1, true];
 };
 if (_isRepairVehicle && {!([_veh] call ace_repair_fnc_isRepairVehicle)}) then {
     _veh setVariable ["ACE_isRepairVehicle", _isRepairVehicle, true];
 };
 if !(_fuelSource isEqualTo []) then {
     _fuelSource params [
-        ["_source", objNull, [objNull]],
         ["_fuelCargo", 0, [0]],
         ["_hooks", nil, [[]]]
     ];
-    [_source, _fuelCargo, _hooks] call ace_refuel_fnc_makeSource;
+    if ((!isNil "_hooks") && {_hooks isEqualTo (_veh getVariable ["ace_refuel_hooks", []])}) then {
+        [_veh, _fuelCargo, _hooks] call ace_refuel_fnc_makeSource;
+    } else {
+        if (_fuelCargo != [_veh] call ace_refuel_fnc_getFuel) then {
+            [_veh, _fuelCargo] call ace_refuel_fnc_makeSource;
+        };
+    };
 };
 if !(_pylons isEqualTo []) then {
-    _fuelSource params [
-        ["_source", objNull, [objNull]],
-        ["_fuelCargo", 0, [0]],
-        ["_hooks", nil, [[]]]
-    ];
     private _pylonPaths = (configProperties [configFile >> "CfgVehicles" >> typeOf _veh >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"]) apply {getArray (_x >> "turret")};
     {
         _veh removeWeaponGlobal getText (configFile >> "CfgMagazines" >> _x >> "pylonWeapon")

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
@@ -3,16 +3,16 @@
 Function: btc_fnc_log_server_repair_wreck
 
 Description:
-    Fill me when you edit me !
+    Repair wreck.
 
 Parameters:
-    _veh - [Object]
+    _veh - Vehicle to repair. [Object]
 
 Returns:
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_log_server_repair_wreck;
+        _veh = [my_vehicle] call btc_fnc_log_server_repair_wreck;
     (end)
 
 Author:

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
@@ -29,6 +29,13 @@ private _type = typeOf _veh;
 private _dir = getDir _veh;
 private _customization = [_veh] call BIS_fnc_getVehicleCustomization;
 private _marker = _veh getVariable ["marker", ""];
+private _isMedicalVehicle = [_veh] call ace_medical_fnc_isMedicalVehicle;
+private _isRepairVehicle = [_veh] call ace_repair_fnc_isRepairVehicle;
+private _fuelSource = [
+    [_veh] call ace_refuel_fnc_getFuel,
+    _veh getVariable ["ace_refuel_hooks", []]
+];
+private _pylons = getPylonMagazines _veh;
 
 btc_vehicles = btc_vehicles - [_veh];
 
@@ -38,6 +45,6 @@ if (_marker != "") then {
 };
 deleteVehicle _veh;
 sleep 1;
-_veh = [_type, [_x, _y, 0.5 + _z], _dir, _customization] call btc_fnc_log_createVehicle;
+_veh = [_type, [_x, _y, 0.5 + _z], _dir, _customization, _isMedicalVehicle, _isRepairVehicle, _fuelSource, _pylons] call btc_fnc_log_createVehicle;
 
 _veh


### PR DESCRIPTION
- FIX: ACE vehicles' parameters not saved in database or after repair wreck (@Vdauphin).

**When merged this pull request will:**
- now it save vehicles parameter like: medical vehicle, repair vehicle, fuelcargo, fuel nozzle position
- save in database and when repair werck
- does not include "cargo space" as it is handle by H&M for gameplay reason: https://github.com/Vdauphin/HeartsAndMinds/issues/644#issuecomment-471327590
- Close #644 

- [x] test database compatibility

**Final test:**
- [x] local
- [x] server