### PR TITLE
FIX: Plane crash when they spawn

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/createVehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/createVehicle.sqf
@@ -39,7 +39,10 @@ params [
 private _needdiver = getText (configFile >> "CfgVehicles" >> _veh_type >> "simulation") isEqualTo "submarinex";
 
 private _veh = createVehicle [_veh_type, _pos, [], 0, "FLY"];
-_veh setdir _dir;
+if !(_veh_type isKindOf "Plane") then {
+    _veh setdir _dir;
+};
+
 private _units = [_veh, _group, false, "", [_type_crewmen, _type_divers select 0] select _needdiver] call BIS_fnc_spawnCrew;
 _group selectLeader (driver _veh);
 _units joinSilent _group;


### PR DESCRIPTION
- FIX: Plane crash when they spawn (@Vdauphin).

**When merged this pull request will:**
- setdir on plane make the velocity of then null so then just fall and crash on the ground
- fix #647 

**Final test:**
- [x] local
- [x] server