### PR TITLE
FIX: Repair wreck detect ACE fastrope

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_check.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_check.sqf
@@ -32,8 +32,7 @@ if (_array isEqualTo []) exitWith {false};
 private _cargo_array = nearestObjects [_chopper, _array, 30];
 _cargo_array = _cargo_array - [_chopper];
 _cargo_array = _cargo_array select {!(
-    _x isKindOf "ACE_friesGantry" ||
-    (typeOf _x) isEqualTo "ACE_friesAnchorBar" ||
+    _x isKindOf "ACE_friesBase" OR
     _x isKindOf "ace_fastroping_helper"
 )};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_hook.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_hook.sqf
@@ -29,8 +29,7 @@ private _cargo_array = nearestObjects [_chopper, _array, 30];
 _cargo_array = _cargo_array - [_chopper];
 _cargo_array = _cargo_array select {
     !(
-    _x isKindOf "ACE_friesGantry" ||
-    (typeOf _x) isEqualTo "ACE_friesAnchorBar" ||
+    _x isKindOf "ACE_friesBase" OR
     _x isKindOf "ace_fastroping_helper"
     )
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_hud_loop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_hud_loop.sqf
@@ -40,8 +40,7 @@ private _cargo_array = nearestObjects [_chopper, _array, 30];
 if (_array isEqualTo []) then {_cargo_array = [];};
 _cargo_array = _cargo_array - [_chopper];
 _cargo_array = _cargo_array select {!(
-    _x isKindOf "ACE_friesGantry" ||
-    (typeOf _x) isEqualTo "ACE_friesAnchorBar" ||
+    _x isKindOf "ACE_friesBase" OR
     _x isKindOf "ace_fastroping_helper"
 )};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/repair_wreck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/repair_wreck.sqf
@@ -24,7 +24,10 @@ params [
     ["_object", objNull, [objNull]]
 ];
 
-private _array = (nearestObjects [_object, ["LandVehicle", "Air"], 10]) select {!((_x isKindOf "ACE_friesGantry") OR (typeOf _x isEqualTo "ACE_friesAnchorBar"))};
+private _array = (nearestObjects [_object, ["LandVehicle", "Air"], 10]) select {!(
+    _x isKindOf "ACE_friesBase" OR
+    _x isKindOf "ace_fastroping_helper"
+)};
 
 if (_array isEqualTo []) exitWith {hint localize "STR_BTC_HAM_LOG_RWRECK_NOWRECK";}; //No wreck found
 


### PR DESCRIPTION
- FIX: Repair wreck detect ACE fastrope (@Vdauphin).

**When merged this pull request will:**
- This remove ACE fastroping things when searching for vehicles
- fix #646 

**Final test:**
- [x] local
- [x] server
