### PR TITLE
FIX: Helo crash instantly when respawned

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_add_respawn.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_add_respawn.sqf
@@ -32,7 +32,9 @@ private _type = typeOf _vehicle;
 private _pos = getPosASL _vehicle;
 private _dir = getDir _vehicle;
 private _customization = [_vehicle] call BIS_fnc_getVehicleCustomization;
-_vehicle setVariable ["data_respawn", [_type, _pos, _dir, _time, _has_marker, _customization]];
+private _vector = [vectorDir _vehicle, vectorUp _vehicle];
+
+_vehicle setVariable ["data_respawn", [_type, _pos, _dir, _time, _has_marker, _customization, _vector]];
 
 if ((isNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "ace_fastroping_enabled")) && !(typeOf _vehicle isEqualTo "RHS_UH1Y_d")) then {[_vehicle] call ace_fastroping_fnc_equipFRIES};
 _vehicle addMPEventHandler ["MPKilled", {if (isServer) then {_this call btc_fnc_eh_veh_respawn};}];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_respawn.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_respawn.sqf
@@ -26,16 +26,18 @@ params [
 
 private _data = _vehicle getVariable ["data_respawn", []];
 
-[_vehicle, _data] spawn {
+[{
     params ["_vehicle", "_data"];
-    _data params ["_type", "_pos", "_dir", "_time", "_has_marker", ["_customization", [false, false]]];
 
-    sleep _time;
     deleteVehicle _vehicle;
-    sleep 1;
-    private _veh = _type createVehicle _pos;
-    [_veh, _customization select 0, _customization select 1] call BIS_fnc_initVehicle;
-    _veh setDir _dir;
-    _veh setPosASL _pos;
-    [_veh, _time, _has_marker] spawn btc_fnc_eh_veh_add_respawn;
-};
+    [{
+        params ["_type", "_pos", "_dir", "_time", "_has_marker", ["_customization", [false, false]], "_vectorPos"];
+
+        private _veh = _type createVehicle _pos;
+        [_veh, _customization select 0, _customization select 1] call BIS_fnc_initVehicle;
+        _veh setDir _dir;
+        _veh setPosASL _pos;
+        _veh setVectorDirAndUp _vectorPos;
+        [_veh, _time, _has_marker] call btc_fnc_eh_veh_add_respawn;
+    }, _data, 1] call CBA_fnc_waitAndExecute;
+}, [_vehicle, _data], _data select 3] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
- FIX: Helo crash instantly when respawned (@Vdauphin).

**When merged this pull request will:**
- Now helo respawn with the vector defined in mission.sqm 
- fix #653 

**Final test:**
- [x] local
- [x] server