### PR TITLE
FIX: btc_fnc_info_hideout take an object as parameter not an array

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/info/give_intel.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/info/give_intel.sqf
@@ -36,11 +36,11 @@ switch (true) do {
     case (_n > (btc_info_intel_type select 1) && _n < 101) : { //both
         _id = 4;
         [true, 0] spawn btc_fnc_info_cache;
-        [true] spawn btc_fnc_info_hideout;
+        [] spawn btc_fnc_info_hideout;
     };
     case (_n > (btc_info_intel_type select 0) && _n < (btc_info_intel_type select 1)) : { //hd
         _id = 5;
-        [true] spawn btc_fnc_info_hideout;
+        [] spawn btc_fnc_info_hideout;
     };
     default {
         _id = 0;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/info/hideout.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/info/hideout.sqf
@@ -21,7 +21,7 @@ Author:
 ---------------------------------------------------------------------------- */
 
 params [
-    ["_ho", btc_hq, [[]]]
+    ["_ho", btc_hq, [objNull]]
 ];
 
 if (btc_hideouts isEqualTo []) exitWith {};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/info/hideout.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/info/hideout.sqf
@@ -3,16 +3,16 @@
 Function: btc_fnc_info_hideout
 
 Description:
-    Fill me when you edit me !
+    Add an random intel marker for the current hideout.
 
 Parameters:
-    _ho - [Array]
+    _ho - Current hideout. [Object]
 
 Returns:
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_info_hideout;
+        [] call btc_fnc_info_hideout;
     (end)
 
 Author:


### PR DESCRIPTION
- FIX: btc_fnc_info_hideout take an object as parameter not an array (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server