### PR TITLE
Add: Save game when all players disconnected

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -6,7 +6,7 @@ diag_log format ["=BTC= HEARTS AND MINDS VERSION %1.4", btc_version];
 btc_p_time = "btc_p_time" call BIS_fnc_getParamValue;
 btc_p_acctime = "btc_p_acctime" call BIS_fnc_getParamValue;
 private _p_db = ("btc_p_load" call BIS_fnc_getParamValue) isEqualTo 1;
-btc_p_auto_db = "btc_p_auto_db" call BIS_fnc_getParamValue;
+btc_p_auto_db = "btc_p_auto_db" call BIS_fnc_getParamValue isEqualTo 1;
 
 //<< Faction options >>
 private _p_en = "btc_p_en" call BIS_fnc_getParamValue;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -23,7 +23,7 @@ class Params {
         texts[]={$STR_DISABLED,$STR_ENABLED};
         default = 1;
     };
-    class btc_p_auto_db { // Auto savegame when all player disconnected
+    class btc_p_auto_db { // Auto savegame when all players disconnected
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_DB_ASAVE"]);
         values[]={0,1};
         texts[]={$STR_DISABLED,$STR_ENABLED}; // texts[]={"Off","On"};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -23,10 +23,10 @@ class Params {
         texts[]={$STR_DISABLED,$STR_ENABLED};
         default = 1;
     };
-    class btc_p_auto_db { // Auto savegame (can break player immersion)
+    class btc_p_auto_db { // Auto savegame when all player disconnected
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_DB_ASAVE"]);
-        values[]={0,1,2,3,4,5,6,7,8,9,10,11,12,24,48,72};
-        texts[]={$STR_DISABLED,"1h","2h","3h","4h","5h","6h","7h","8h","9h","10h","11h","12h","24h","48h","72h"}; // texts[]={"Off","1h","2h","3h","4h","5h","6h","7h","8h","9h","10h","11h","12h","24h","48h","72h"};
+        values[]={0,1};
+        texts[]={$STR_DISABLED,$STR_ENABLED}; // texts[]={"Off","On"};
         default = 0;
     };
     class btc_p_type_title { // << Faction options >>

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/autosave.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/autosave.sqf
@@ -3,7 +3,7 @@
 Function: btc_fnc_db_autosave
 
 Description:
-    Save game when all player disconnected.
+    Save game when all players disconnected.
 
 Parameters:
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/autosave.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/autosave.sqf
@@ -3,15 +3,16 @@
 Function: btc_fnc_db_autosave
 
 Description:
-    Fill me when you edit me !
+    Save game when all player disconnected.
 
 Parameters:
 
 Returns:
+    _this - Passed arguments. [Array]
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_db_autosave;
+        [] call btc_fnc_db_autosave;
     (end)
 
 Author:
@@ -19,11 +20,12 @@ Author:
 
 ---------------------------------------------------------------------------- */
 
-
-if (btc_p_auto_db > 0) then {
-    // Save 5 minutes before, so it saves on time.
-    [{
-        [] spawn btc_fnc_db_save;
-        call btc_fnc_db_autosave;
-    }, [], btc_p_auto_db * 60 * 60 - 300] call CBA_fnc_waitAndExecute;
+if ((allPlayers - entities "HeadlessClient_F") isEqualTo []) then {
+    removeMissionEventHandler ["HandleDisconnect", _thisEventHandler];
+    [] spawn {
+        [false] call btc_fnc_db_save;
+        addMissionEventHandler ["HandleDisconnect", btc_fnc_db_autosave];
+    };
 };
+
+_this

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/server.sqf
@@ -3,7 +3,7 @@
 Function: btc_fnc_eh_server
 
 Description:
-    Add event handler to player.
+    Add event handler to server.
 
 Parameters:
 
@@ -22,3 +22,7 @@ Author:
 addMissionEventHandler ["HandleDisconnect", btc_fnc_eh_handledisconnect];
 addMissionEventHandler ["BuildingChanged", btc_fnc_eh_buildingchanged];
 ["ace_explosives_defuse", btc_fnc_eh_explosives_defuse] call CBA_fnc_addEventHandler;
+
+if (btc_p_auto_db) then {
+    addMissionEventHandler ["HandleDisconnect", btc_fnc_db_autosave];
+};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -21,7 +21,6 @@ if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db", worldN
     } forEach btc_vehicles;
 };
 
-[] call btc_fnc_db_autosave;
 [] call btc_fnc_eh_server;
 [btc_ied_list] call btc_fnc_ied_fired_near;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -288,10 +288,7 @@
                 <Chinesesimp>载入存档 (如果可用)</Chinesesimp>
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_DB_ASAVE">
-                <Original>Auto savegame (can break player immersion)</Original>
-                <German>Spielstand autom. sichern (kann die Immersion stören)</German>
-                <Portuguese>Salvamento do jogo automático (pode quebrar a imersão do jogador)</Portuguese>
-                <Chinesesimp>自动保存 (存档时会暂停游戏进程, 可能破坏玩家的沉浸感)</Chinesesimp>
+                <Original>Auto savegame when all player disconnected</Original>
             </Key>
         </Container>
         <Container name="Parameters: Factions">

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -288,7 +288,8 @@
                 <Chinesesimp>载入存档 (如果可用)</Chinesesimp>
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_DB_ASAVE">
-                <Original>Auto savegame when all player disconnected</Original>
+                <Original>Auto savegame when all players disconnected</Original>
+                <German>Spiel wird automatisch Gespeichert, wenn alle Spieler das Spiel verlassen</German>
             </Key>
         </Container>
         <Container name="Parameters: Factions">


### PR DESCRIPTION
- Add: Save game when on allplayers disconnected (@Vdauphin).

**When merged this pull request will:**
- title
- autosave game break player experience when it is done during combat. Create a lot of confusion. In game, this should be only done with the seft interaction by admin
- remove https://github.com/Vdauphin/HeartsAndMinds/pull/233
- remove request: https://github.com/Vdauphin/HeartsAndMinds/issues/220

**Final test:**
- [x] local
- [x] server