### PR TITLE
FIX: PlaySound3D, allah akbar sound doesn't trigger on my server

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/allahu_akbar.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/allahu_akbar.sqf
@@ -29,7 +29,7 @@ private _suicider = _trigger getVariable "suicider";
 private _soundPath = [str missionConfigFile, 0, -15] call BIS_fnc_trimString;
 private _soundToPlay = _soundPath + "core\sounds\allahu_akbar.ogg";
 if (alive _suicider && [_suicider] call ace_common_fnc_isAwake) then {
-    playSound3d [_soundToPlay, _suicider, false, getPosASL _suicider, 40, random [0.9, 1, 1.2], 100];
+    playSound3d [_soundToPlay, _suicider, false, getPosASL _suicider, 5, random [0.9, 1, 1.2], 100];
 };
 
 [{


### PR DESCRIPTION
- FIX: FIX: PlaySound3D, allah akbar sound doesn't trigger on my server since 1.92 (@Vdauphin).

**When merged this pull request will:**
- Since 1.92 playSound3D take a sound volume lower than 5
- https://forums.bohemia.net/forums/topic/165948-mp-btc-hearts-and-minds/?page=53&tab=comments#comment-3359025

**Final test:**
- [x] local
- [x] server