### PR TITLE
FIX: Convert ASL to ATL when over sea

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/civtreatment.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/civtreatment.sqf
@@ -86,7 +86,6 @@ _group setVariable ["no_cache", true];
 private _unit =_group createUnit [_unit_type, _pos, [], 0, "CAN_COLLIDE"];
 _unit setBehaviour "CARELESS";
 _unit setDir (random 360);
-_unit setPosATL _pos;
 _unit setUnitPos "DOWN";
 {_x call btc_fnc_civ_unit_create} forEach units _group;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hack.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hack.sqf
@@ -50,7 +50,7 @@ _marker setMarkerType "hd_flag";
 _marker setMarkerSize [0.6, 0.6];
 
 //// Create terminal \\\\
-private _terminal = createVehicle ["Land_DataTerminal_01_F", _pos, [], 0, "CAN_COLLIDE"];
+private _terminal = createVehicle ["Land_DataTerminal_01_F", [_pos, ASLToATL _pos] select surfaceIsWater _pos, [], 0, "CAN_COLLIDE"];
 _pos = [[_pos, 100] call btc_fnc_randomize_pos, 50, 500, 30, 0, 60 * (pi / 180), 0] call BIS_fnc_findSafePos;
 private _launchsite = createVehicle ["Land_PenBlack_F", _pos, [], 0, "FLY"];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
@@ -65,15 +65,13 @@ _group_civ setVariable ["no_cache", true];
 private _captive = _group_civ createUnit [selectRandom btc_civ_type_units, _pos, [], 0, "CAN_COLLIDE"];
 waitUntil {local _captive};
 [_captive, true] call ACE_captives_fnc_setHandcuffed;
-_captive setPosATL _pos;
 _captive call btc_fnc_civ_unit_create;
 
 private _group = [];
 {
     private _grp = createGroup btc_enemy_side;
-    private _unit = _grp createUnit [selectRandom btc_type_units, _x, [], 0, "NONE"];
+    private _unit = _grp createUnit [selectRandom btc_type_units, _x, [], 0, "CAN_COLLIDE"];
     [_unit] joinSilent _grp;
-    _unit setPosATL _x;
     _group pushBack _grp;
     _grp setVariable ["no_cache", true];
     _unit call btc_fnc_mil_unit_create;


### PR DESCRIPTION
- FIX: Convert ASL to ATL when over sea (@Vdauphin).

**When merged this pull request will:**
- building pos return ASL when position is over see
- prevent object spawning in objects when there are over sea

**Final test:**
- [x] local
- [x] server