### PR TITLE
FIX: Avoid Van_02_vehicle_base_F because BI fault

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/createVehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/createVehicle.sqf
@@ -37,6 +37,9 @@ params [
 ];
 
 private _needdiver = getText (configFile >> "CfgVehicles" >> _veh_type >> "simulation") isEqualTo "submarinex";
+if (_veh_type isKindOf "Van_02_vehicle_base_F") then {
+    _veh_type = "I_C_Van_02_transport_F"; // https://feedback.bistudio.com/T129141
+};
 
 private _veh = createVehicle [_veh_type, _pos, [], 0, "FLY"];
 if !(_veh_type isKindOf "Plane") then {


### PR DESCRIPTION
- FIX: Avoid Van_02_vehicle_base_F because BI fault (@Vdauphin).

**When merged this pull request will:**
- title
- https://feedback.bistudio.com/T129141
- fix #668

**Final test:**
- [x] local
- [x] server