### PR TITLE
FIX: Some patrol can spawn in water

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/find_closecity.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/find_closecity.sqf
@@ -24,7 +24,7 @@ Author:
 ---------------------------------------------------------------------------- */
 
 params [
-    ["_obj", objNull, [objNull]],
+    ["_obj", objNull, [objNull, []]],
     ["_array", [], [[]]],
     ["_isOccupied", true, [true]]
 ];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/find_closecity.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/find_closecity.sqf
@@ -8,7 +8,7 @@ Description:
 Parameters:
     _obj - City used to find the closer city. [Object]
     _array - Array of city. [Array]
-    _isOccupied - Filter city by their occupation by enemies. [Boolean]
+    _isOccupied - Activate not occupied city filter. [Boolean]
 
 Returns:
     _closer_city - Closer city from the array of city. [Object]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/rep/call_militia.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/rep/call_militia.sqf
@@ -42,13 +42,10 @@ if (btc_debug_log) then {
 };
 
 if (_start_pos isEqualTo []) then {
-    {
-        private _city = _x;
-        if (_pos distance _city > 300 && {_city inArea [_pos, 2500, 2500, 0, false]} && {_players inAreaArray [getPosWorld _city, 500, 500] isEqualTo []}) then {
-            _start_pos = getPos _city;
-        };
-    } forEach btc_city_all;
+    _start_pos = [_pos, btc_city_all select {!(_x getVariable ["active", false]) && _x getVariable ["type", ""] != "NameMarine"}, true] call btc_fnc_find_closecity;
+    _start_pos = getPos _start_pos;
 };
+
 if (btc_debug_log) then {
     [format ["_start_pos : %1 (CITIES)", _start_pos], __FILE__, [false]] call btc_fnc_debug_message;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/rep/call_militia.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/rep/call_militia.sqf
@@ -42,7 +42,7 @@ if (btc_debug_log) then {
 };
 
 if (_start_pos isEqualTo []) then {
-    _start_pos = [_pos, btc_city_all select {!(_x getVariable ["active", false]) && _x getVariable ["type", ""] != "NameMarine"}, true] call btc_fnc_find_closecity;
+    _start_pos = [_pos, btc_city_all select {!(_x getVariable ["active", false]) && _x getVariable ["type", ""] != "NameMarine"}, false] call btc_fnc_find_closecity;
     _start_pos = getPos _start_pos;
 };
 


### PR DESCRIPTION
- FIX: Some patrol can spawn in water (@Vdauphin).

**When merged this pull request will:**
- Don't select marine location to avoid swiming unit when calling call_militia

**Final test:**
- [x] local
- [x] server