### PR TITLE
Update repair_wreck.sqf

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/repair_wreck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/repair_wreck.sqf
@@ -24,7 +24,7 @@ params [
     ["_object", objNull, [objNull]]
 ];
 
-private _array = (nearestObjects [_object, ["LandVehicle", "Air"], 10]) select {!(
+private _array = (nearestObjects [_object, ["LandVehicle", "Air", "Ships"], 10]) select {!(
     _x isKindOf "ACE_friesBase" OR
     _x isKindOf "ace_fastroping_helper"
 )};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/repair_wreck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/repair_wreck.sqf
@@ -24,7 +24,7 @@ params [
     ["_object", objNull, [objNull]]
 ];
 
-private _array = (nearestObjects [_object, ["LandVehicle", "Air", "Ships"], 10]) select {!(
+private _array = (nearestObjects [_object, ["LandVehicle", "Air", "Ship"], 10]) select {!(
     _x isKindOf "ACE_friesBase" OR
     _x isKindOf "ace_fastroping_helper"
 )};


### PR DESCRIPTION
- FIX: "Ship" vehicle class in wreck repair was missing (@heitor-sampaio).

**When merged this pull request will:**
- Changed line 27 to add  ships to repair wreck system.
- Added "Ships" vehicle class to wreck repair. Very important to Tanoa version.

**Final test:**
- [x] local
- [x] server