### PR TITLE
FIX: Enemy doesn't spawn inside the city radius

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/init.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/init.sqf
@@ -62,6 +62,11 @@ for "_i" from 0 to (count _locations - 1) do {
         if ((getMarkerPos "YOUR_MARKER_AREA") inArea [_position, 500, 500, 0, false]) exitWith {};
         */
 
+        if (_radius_x < 80 || _radius_y < 80) then {
+            _radius_x = 80;
+            _radius_y = 80;
+        };
+
         [_position, _type, _name, _radius_x, _radius_y, random 1 > 0.45] call btc_fnc_city_create;
     };
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_group.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_group.sqf
@@ -42,7 +42,7 @@ params [
 _wp_ratios params ["_wp_house_probability", "_wp_sentry_probability"];
 
 // Find a position
-([_city] call btc_fnc_city_findPos) params ["_rpos", "_pos_iswater"];
+([_city, _area] call btc_fnc_city_findPos) params ["_rpos", "_pos_iswater"];
 
 private _group = createGroup _enemy_side;
 private _groups = [];


### PR DESCRIPTION
- FIX: Enemies don't spawn inside the city radius (@Vdauphin).

**When merged this pull request will:**
- title
- fixes #751
- with the add of the `_area`, even with a radius of 80m, the deactivation.sqf works as intended
- before fix, radius list sorted:
   - Lythium:
[15,25,25,50,50,50,50,50,50,50,50,50,50,50,50,50,90,90,90,100,100,100,100,100,100,100,100,100,100,100,100,100,100,100,100,100,100,100,130,150,200,200,200,200,200,200,200,200,200,200,200,250,290,300,300,300,300,390,400,400,500,500,500]
  - Altis:
[150,150,150,200,200,200,200,200,200,200,200,200,200,200,200,220,250,250,250,250,250,260.96,260.96,260.96,260.96,270.58,277.27,277.27,300,300,300,300,300,300,300,300,300,300,300,300,300,300,<null>,<null>,<null>,300,300,300,300,300,300,300,300,300,300,300,300,300,346.59,350,350,350,350,350,350,350,371.91,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,<null>,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,400,433.24,450,450,450,450,450,450,450,453.27,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,500,509.68,600,600,600,600,629.96,690,734.49,800]

  - Tanoa:
[80,100,120,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,200,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,250,300,300,300,300,300,300,300,300,300,300,300,300,300,300,300,300,300,300,300,300,300,300,327.33,349.99,350,390,400,400,400,400,400,413.18,450,450,450,450,450,450,450,450,500,500,500,500,500,500,500,500,600,600,600,600,600,600,600,600]

**Final test:**
- [x] local
- [x] server