### PR TITLE
FIX: RopeCreate fail return objtNull

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_hook.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/lift_hook.sqf
@@ -48,7 +48,7 @@ if !(_bbr isEqualTo []) then {
 };
 
 private _rope_length = 10;
-if ((_bbr isEqualTo []) OR (_ropes_check isEqualTo [])) then {
+if ((_bbr isEqualTo []) OR (_ropes_check select {!isNull _x} isEqualTo [])) then {
 
     _bbr = boundingBoxReal _cargo;
     if (abs((_bbr select 0) select 0) > 5) then {


### PR DESCRIPTION
- FIX: Can't sling load werck and some RHS vehicles (@Vdauphin).

**When merged this pull request will:**
- title
- `ropeCreate` return `objNull` instead of `nil` since 1.94

**Final test:**
- [x] local
- [x] server

**Screenshots**

![20190820104343_1](https://user-images.githubusercontent.com/14364400/63341560-c7957300-c349-11e9-87d6-8d3b9b9da5ec.jpg)
![20190820105304_1](https://user-images.githubusercontent.com/14364400/63341561-c82e0980-c349-11e9-932b-7772e6faa2af.jpg)
