### PR TITLE
 FIX: FOB spawn twice when two players create a FOB

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/create.sqf
@@ -76,6 +76,8 @@ closeDialog 0;
 [{
     params ["_pos", "_mat", "_name"];
 
+    if (isNull _mat) exitWith {};
+
     deleteVehicle _mat;
     private _FOB_name = "FOB " + _name;
     [_pos, _FOB_name] remoteExecCall ["btc_fnc_fob_create_s", 2];


### PR DESCRIPTION
- FIX: FOB spawn twice when two player create a FOB (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server