### PR TITLE
FIX: Logistic point don't show selected objects since A3 1.96

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/description.ext
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/description.ext
@@ -54,3 +54,5 @@ class Extended_InitPost_EventHandlers {
 // Disable BI wreck system (H&M handle it internally)
 wreckManagerMode = 0;
 corpseManagerMode = 0;
+
+unsafeCVL = 1;


### PR DESCRIPTION
- FIX: Logistic point don't show selected objects since A3 1.96 (@Vdauphin).

**When merged this pull request will:**
- title
- `createVehicleLocal` doesn't work on server because security ...

**Final test:**
- [ ] local
- [ ] server