### PR TITLE
FIX: Wrong icon for deploying rope in ship

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_init.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_init.sqf
@@ -59,7 +59,7 @@ switch true do {
     };
     case (_type isKindOf "Ship") : {
         //Lift
-        private _action = ["Deploy_ropes", localize "STR_BTC_HAM_ACTION_VEHINIT_DEPLOYROPES", "\A3\Structures_F_Heli\VR\Helpers\Data\VR_Symbol_Heli_Slingloading_CA.paa", {[] spawn btc_fnc_log_lift_deploy_ropes;}, {!btc_ropes_deployed && {(driver vehicle player) isEqualTo player}}] call ace_interact_menu_fnc_createAction; //Deploy ropes
+        private _action = ["Deploy_ropes", localize "STR_BTC_HAM_ACTION_VEHINIT_DEPLOYROPES", "\A3\ui_f\data\igui\cfg\simpleTasks\types\container_ca.paa", {[] spawn btc_fnc_log_lift_deploy_ropes;}, {!btc_ropes_deployed && {(driver vehicle player) isEqualTo player}}] call ace_interact_menu_fnc_createAction; //Deploy ropes
         [_type, 1, ["ACE_SelfActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
         _action = ["Cut_ropes", localize "STR_BTC_HAM_ACTION_VEHINIT_CUTROPES", "\z\ace\addons\logistics_wirecutter\ui\wirecutter_ca.paa", {[] spawn btc_fnc_log_lift_destroy_ropes;}, {btc_ropes_deployed && {(driver vehicle player) isEqualTo player}}] call ace_interact_menu_fnc_createAction; //Cut ropes
         [_type, 1, ["ACE_SelfActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/rep/eh_effects.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/rep/eh_effects.sqf
@@ -6,7 +6,7 @@ Description:
     Add effects when player do bad things (call militia, take weapons/grenade).
 
 Parameters:
-    _pos - Poistion where bad stuff happened. [Array]
+    _pos - Position where bad stuff happened. [Array]
 
 Returns:
 


### PR DESCRIPTION
- FIX: Wrong icon for deploying rope in ship (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server