### PR TITLE
FIX: Chemical damage lag when a lot of units are contaminated

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/checkLoop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/checkLoop.sqf
@@ -75,17 +75,22 @@ private _bodyParts = ["head","body","hand_l","hand_r","leg_l","leg_r"];
         private _pos = getPosWorld _x;
         _unitContaminate append (_units inAreaArray [_pos, _range, _range, 0, false, 2 + (_pos select 2)]);
     } forEach _contaminated;
+
+    if (_unitContaminate isEqualTo []) exitWith {};
+    private _periode = 3 / count _unitContaminate;
     {
         private _notAlready = _contaminated pushBackUnique _x > -1;
         if (_notAlready) then {
             publicVariable "btc_chem_contaminated";
         };
         if (local _x) then {
-            [_x, _notAlready, _bodyParts, _cfgGlasses] call btc_fnc_chem_damage;
+            [{
+                _this call btc_fnc_chem_damage;
+            }, [_x, _notAlready, _bodyParts, _cfgGlasses], _forEachIndex * _periode] call CBA_fnc_waitAndExecute;
         } else {
             if (_notAlready) then {
                 [_x] remoteExecCall ["btc_fnc_chem_damageLoop", _x];
             };
         };
     } forEach _unitContaminate;
-}, 3, [btc_chem_contaminated, btc_chem_decontaminate, btc_chem_range, _bodyParts, configFile >> "CfgGlasses"]] call CBA_fnc_addPerFrameHandler;
+}, 3.1, [btc_chem_contaminated, btc_chem_decontaminate, btc_chem_range, _bodyParts, configFile >> "CfgGlasses"]] call CBA_fnc_addPerFrameHandler;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/cleanUp.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/cleanUp.sqf
@@ -46,3 +46,9 @@ _toRemove append (allGroups select {
 });
 
 _toRemove call CBA_fnc_deleteEntity;
+
+while {objNull in btc_chem_contaminated} do {
+    btc_chem_contaminated deleteAt (
+        btc_chem_contaminated find objNull
+    )
+};


### PR DESCRIPTION
- FIX: Chemical damage lag when a lot of units are contaminated (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server