### PR TITLE
FIX: Game crash while searching intel

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -30,7 +30,9 @@ _action = ["request_delete", localize "STR_3DEN_Delete", "\A3\ui_f\data\igui\cfg
 [player, 1, ["ACE_SelfActions", "Database"], _action] call ace_interact_menu_fnc_addActionToObject;
 
 //Intel
-_action = ["Search_intel", localize "STR_A3_Showcase_Marksman_BIS_tskIntel_title", "\A3\ui_f\data\igui\cfg\simpleTasks\types\search_ca.paa", {(_this select 0) call btc_fnc_info_search_for_intel;}, {!alive (_this select 0)}] call ace_interact_menu_fnc_createAction;
+_action = ["Search_intel", localize "STR_A3_Showcase_Marksman_BIS_tskIntel_title", "\A3\ui_f\data\igui\cfg\simpleTasks\types\search_ca.paa", {
+    [btc_fnc_info_search_for_intel, [_this select 0]] call CBA_fnc_execNextFrame;
+}, {!alive (_this select 0)}] call ace_interact_menu_fnc_createAction;
 {[_x, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToClass;} forEach (btc_type_units + btc_type_divers);
 _action = ["Interrogate_intel", localize "STR_BTC_HAM_ACTION_INTEL_INTERROGATE", "\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\instructor_ca.paa", {[(_this select 0),true] spawn btc_fnc_info_ask;}, {alive (_this select 0) && {[_this select 0] call ace_common_fnc_isAwake} && captive (_this select 0)}] call ace_interact_menu_fnc_createAction;
 {[_x, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToClass;} forEach (btc_type_units + btc_type_divers);


### PR DESCRIPTION
- FIX: Game crash while searching intel (@Vdauphin).

**When merged this pull request will:**
- title
> commy2:bomb:  6:35 PM
>Use execNextFrame. Probably something about creating displays and deleting displays from a ui script.
>pabstmirror  6:35 PM
>it shouldn't cause the crash, but a lot of times you want to execNextFrame

**Final test:**
- [x] local
- [x] server


[Arma3_x64_2020-03-14_18-16-55.zip](https://github.com/Vdauphin/HeartsAndMinds/files/4333129/Arma3_x64_2020-03-14_18-16-55.zip)
