### PR TITLE
Add: Auto restart/shutdown 

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -9,6 +9,7 @@ btc_p_acctime = "btc_p_acctime" call BIS_fnc_getParamValue;
 private _p_db = ("btc_p_load" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_auto_db = "btc_p_auto_db" call BIS_fnc_getParamValue isEqualTo 1;
 btc_p_db_autoRestart = "btc_p_db_autoRestart" call BIS_fnc_getParamValue;
+btc_p_db_autoRestartTime = "btc_p_db_autoRestartTime" call BIS_fnc_getParamValue;
 
 //<< Faction options >>
 private _p_en = "btc_p_en" call BIS_fnc_getParamValue;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -8,6 +8,7 @@ btc_p_time = "btc_p_time" call BIS_fnc_getParamValue;
 btc_p_acctime = "btc_p_acctime" call BIS_fnc_getParamValue;
 private _p_db = ("btc_p_load" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_auto_db = "btc_p_auto_db" call BIS_fnc_getParamValue isEqualTo 1;
+btc_p_db_autoRestart = "btc_p_db_autoRestart" call BIS_fnc_getParamValue;
 
 //<< Faction options >>
 private _p_en = "btc_p_en" call BIS_fnc_getParamValue;
@@ -121,6 +122,7 @@ if (isServer) then {
     //Database
     btc_db_is_saving = false;
     btc_db_load = _p_db;
+    btc_db_serverCommandPassword = "btc_password"; //Define the same password in server.cfg like this: serverCommandPassword = "btc_password";
 
     //Hideout
     btc_hideouts = [];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -29,6 +29,18 @@ class Params {
         texts[]={$STR_DISABLED,$STR_ENABLED}; // texts[]={"Off","On"};
         default = 0;
     };
+    class btc_p_db_autoRestart { // Auto restart/shutdown server (Must define in server.cfg: serverCommandPassword = "btc_password")
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_DB_ARESTART"]);
+        values[]={0,1,2,3,4};
+        texts[]={$STR_DISABLED,$STR_DISP_MP_DS_RESTART,$STR_BTC_HAM_PARAM_DB_SHUTDOWN,$STR_BTC_HAM_PARAM_DB_SAVERESTART, $STR_BTC_HAM_PARAM_DB_SAVESHUTDOWN}; // texts[]={"Off","Restart", "Shutdown","Save and restart", "Save and shutdown"};
+        default = 0;
+    };
+    class btc_p_db_autoRestartTime { // Time before auto restart/shutdown server
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_DB_ARESTARTTIME"]);
+        values[]={1,2,3,4,5,6,7,8,9,10,11,12,24,48,72};
+        texts[]={"1h","2h","3h","4h","5h","6h","7h","8h","9h","10h","11h","12h","24h","48h","72h"};
+        default = 72;
+    };
     class btc_p_type_title { // << Faction options >>
         title = $STR_BTC_HAM_PARAM_FAC_TITLE;
         values[]={0};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/show_hint.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/show_hint.sqf
@@ -94,6 +94,11 @@ private _text = switch (_type) do {
     case 18 : {
         localize "STR_BTC_HAM_O_FOB_DISMANTLE_H_PROC";
     };
+    case 19 : {
+        [
+            localize "STR_BTC_HAM_O_COMMON_REBOOT", 1.5, [1, 0, 0]
+        ];
+    };
 };
 
 _text call CBA_fnc_notify;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -63,6 +63,7 @@ if (isServer) then {
     btc_fnc_db_loadObjectStatus = compile preprocessFileLineNumbers "core\fnc\db\loadObjectStatus.sqf";
     btc_fnc_db_saveObjectStatus = compile preprocessFileLineNumbers "core\fnc\db\saveObjectStatus.sqf";
     btc_fnc_db_loadCargo = compile preprocessFileLineNumbers "core\fnc\db\loadcargo.sqf";
+    btc_fnc_db_autoRestart = compile preprocessFileLineNumbers "core\fnc\db\autoRestart.sqf";
 
     //DELAY
     btc_fnc_delay_createUnit = compile preprocessFileLineNumbers "core\fnc\delay\createUnit.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/autoRestart.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/autoRestart.sqf
@@ -1,0 +1,43 @@
+
+/* ----------------------------------------------------------------------------
+Function: btc_fnc_db_autoRestart
+
+Description:
+    Restart server.
+
+Parameters:
+    _p_autoRestart - 0 no auto restart, 1 autorestart, 2 auto save and restart. [Number]
+    _serverCommandPassword - Password defineed in server.cfg. [String]
+
+Returns:
+
+Examples:
+    (begin example)
+        [] call btc_fnc_db_autoRestart;
+    (end)
+
+Author:
+    Vdauphin
+
+---------------------------------------------------------------------------- */
+
+params [
+    ["_p_autoRestart", btc_p_db_autoRestart, [0]],
+    ["_serverCommandPassword", btc_db_serverCommandPassword, ""]
+];
+
+if (_p_autoRestart isEqualTo 2) then {
+    if !(btc_db_is_saving) then {
+        btc_db_is_saving = true;
+        [] spawn btc_fnc_db_save;
+    };
+    [{!btc_db_is_saving}, {
+        if !(_this serverCommand "#restartserver") then {
+            ["STR_STEAM_RESULT_INVALID_PASSWORD", {systemChat localize _this}] remoteExecCall ["call", [0, -2] select isDedicated];
+        };
+    }, _serverCommandPassword] call CBA_fnc_waitUntilAndExecute;
+} else {
+    if !(_serverCommandPassword serverCommand "#restartserver") then {
+        ["STR_STEAM_RESULT_INVALID_PASSWORD", {systemChat localize _this}] remoteExecCall ["call", [0, -2] select isDedicated];
+    };
+};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/autosave.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/autosave.sqf
@@ -23,7 +23,9 @@ Author:
 if ((allPlayers - entities "HeadlessClient_F") isEqualTo []) then {
     removeMissionEventHandler ["HandleDisconnect", _thisEventHandler];
     [] spawn {
-        [] call btc_fnc_db_save;
+        if !(btc_db_is_saving) then {
+            [] call btc_fnc_db_save;
+        };
         addMissionEventHandler ["HandleDisconnect", btc_fnc_db_autosave];
     };
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -30,8 +30,11 @@ if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db", worldN
 [] call btc_fnc_spect_checkLoop;
 if (btc_p_db_autoRestart > 0) then {
     [{
-        [] call btc_fnc_db_autoRestart;
-    }, [], 24 * 60 * 60] call CBA_fnc_waitAndExecute;
+        [19] remoteExecCall ["btc_fnc_show_hint", [0, -2] select isDedicated];
+        [{
+            [] call btc_fnc_db_autoRestart;
+        }, [], 5 * 60] call CBA_fnc_waitAndExecute;
+    }, [], btc_p_db_autoRestartTime * 60 * 60 - 5 * 60] call CBA_fnc_waitAndExecute;
 };
 
 ["Initialize"] call BIS_fnc_dynamicGroups;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -28,6 +28,11 @@ if (btc_db_load && {profileNamespace getVariable [format ["btc_hm_%1_db", worldN
 [] call btc_fnc_chem_checkLoop;
 [] call btc_fnc_chem_handleShower;
 [] call btc_fnc_spect_checkLoop;
+if (btc_p_db_autoRestart > 0) then {
+    [{
+        [] call btc_fnc_db_autoRestart;
+    }, [], 24 * 60 * 60] call CBA_fnc_waitAndExecute;
+};
 
 ["Initialize"] call BIS_fnc_dynamicGroups;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -262,6 +262,21 @@
                 <German>Spiel wird automatisch Gespeichert, wenn alle Spieler das Spiel verlassen</German>
                 <Chinesesimp>所有玩家离线后自动存档</Chinesesimp>
             </Key>
+            <Key ID="STR_BTC_HAM_PARAM_DB_ARESTART">
+                <Original>Auto restart/shutdown server (Must define in server.cfg: serverCommandPassword = "btc_password")</Original>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_DB_SHUTDOWN">
+                <Original>Shutdown</Original>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_DB_SAVERESTART">
+                <Original>Save and restart</Original>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_DB_SAVESHUTDOWN">
+                <Original>Save and shutdown</Original>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_DB_ARESTARTTIME">
+                <Original>Time before auto restart/shutdown server</Original>
+            </Key>
         </Container>
         <Container name="Parameters: Factions">
             <Key ID="STR_BTC_HAM_PARAM_FAC_TITLE">
@@ -1790,6 +1805,9 @@
                 <Original>Isn't a side mission, can't abort</Original>
                 <German>Nur Nebenmissionen können abgebrochen werden</German>
                 <Chinesesimp>只能中止支线任务</Chinesesimp>
+            </Key>
+            <Key ID="STR_BTC_HAM_O_COMMON_REBOOT">
+                <Original>Server reboot in 5min, leave it NOW!</Original>
             </Key>
         </Container>
         <Container name="Other: Shortcuts">


### PR DESCRIPTION
- Add: Auto restart/shutdown (@Vdauphin).

**When merged this pull request will:**
- title
- [x] works on linux and windows dedicated
- [x] advise player about restart 5 min before
- [x] time before auto
- [x] #shutdown
- https://github.com/Vdauphin/HeartsAndMinds/issues/400

**Final test:**
- [x] local
- [x] server

**Screenshot:**
![20200413155342_1](https://user-images.githubusercontent.com/14364400/79125832-198a7d80-7d9f-11ea-8c62-793d3b3664e3.jpg)
