### PR TITLE
FIX: Lift wreck flip

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/lift/hookFake.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/lift/hookFake.sqf
@@ -26,7 +26,7 @@ params [
     ["_chopper", objNull, [objNull]]
 ];
 
-private _simulation = createVehicle ["Box_T_NATO_WpsSpecial_F", getPosATL _cargo , [], 0, "CAN_COLLIDE"];
+private _simulation = createVehicle ["Box_EAF_AmmoVeh_F", getPosATL _cargo , [], 0, "CAN_COLLIDE"];
 _simulation enableSimulation false;
 (getPosATL _cargo) params ["_x", "_y", "_z"];
 _simulation setPosATL [_x, _y, [_z, 0] select (_z < -0.05)];


### PR DESCRIPTION
- FIX: Lift wreck flip (@Vdauphin).

**When merged this pull request will:**
- title
- Use a heavier object and bigger to avoid wreck flip during lift

**Final test:**
- [x] local
- [x] server