### PR TITLE
FIX: FOB respawn position can be empty

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
@@ -57,7 +57,12 @@ private _respawn_positions = _fobs_structure apply {
     if (_positions isEqualTo []) then {
         _x modelToWorld [0, 1.5, 0]
     } else {
-        selectRandom (_positions select {_x select 2 < 1})
+        private _availablePos = _positions select {_x select 2 < 1};
+        if (_availablePos isEqualTo []) then {
+            selectRandom _positions
+        } else {
+            selectRandom _availablePos
+        };
     };
 };
 


### PR DESCRIPTION
- FIX: FOB respawn position can be empty (@Vdauphin).

**When merged this pull request will:**
- title
- https://github.com/Vdauphin/HeartsAndMinds/issues/738#issuecomment-613707410

**Final test:**
- [x] local
- [x] server

**Screenshot**
Typical case where the issue appearing:
![20200415092519_1](https://user-images.githubusercontent.com/14364400/79311085-31781380-7efd-11ea-9027-3d430eef0df7.jpg)
