### PR TITLE
FIX: Prevent civilian to stand up if in vehicle after ordering civilian to get down

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/orders_behaviour.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/orders_behaviour.sqf
@@ -47,6 +47,7 @@ switch (_order) do {
     };
     case 2 : {
         doStop _unit;
+        if (vehicle _unit != _unit) exitWith {};
         [_unit, "", 2] call ace_common_fnc_doAnimation;
         _unit setUnitPos "DOWN";
     };


### PR DESCRIPTION
- FIX: Prevent civilian to stand up if in vehicle after ordering civilian to get down (@mrNo0b) 

**When merged this pull request will:**
- title
- When ordering civilian to get down he will stand up if he is in vehicle, causing him to clip thru the car roof 

**Final test:**
- [x] local
- [x] server

**Screenshot:**
![bug1](https://user-images.githubusercontent.com/12209347/79584232-cc781580-80d6-11ea-9b4e-47ec8de0c4ab.png)