### PR TITLE
FIX: Skip side mission mines if no safe position found

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/mines.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/mines.sqf
@@ -29,6 +29,7 @@ if (_useful isEqualTo []) then {_useful = + (btc_city_all select {!(isNull _x)})
 
 private _city = selectRandom _useful;
 private _pos = [getPos _city, 0, 500, 30, false] call btc_fnc_findsafepos;
+if (_pos select 2 > 50) exitWith {[] spawn btc_fnc_side_create;};
 
 [_taskID, 4, _pos, _city getVariable "name"] call btc_fnc_task_create;
 


### PR DESCRIPTION
- FIX: Skip side mission mines if no safe position found (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server