### PR TITLE
FIX: Avoid reputation up while checking civilian medical status

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/rep/treatment.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/rep/treatment.sqf
@@ -31,6 +31,6 @@ params [
 ];
 
 if (isPlayer _target) exitWith {};
-if ((alive _target) && (side _target isEqualTo civilian) && !(_className isEqualTo "Diagnose")) then {
+if ((alive _target) && (side _target isEqualTo civilian) && !(_className in ["CheckPulse", "CheckBloodPressure", "CheckResponse"])) then {
     _this remoteExecCall ["btc_fnc_rep_hh", 2];
 };


### PR DESCRIPTION
- FIX: Avoid reputation up while checking civilian medical status (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server