### PR TITLE
FIX: Impossible to remove spawned "Land_PortableLight_double_F"

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -504,7 +504,7 @@ btc_log_main_rc = [
     "Ship", 50,
     "Helicopter", 9999,
     "Car", 35,
-    "Lamps_base_F", 3
+    "Lamps_base_F", 2
 ];
 btc_log_def_cc = [
     "Land_CargoBox_V1_F", 0,

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -503,7 +503,8 @@ btc_log_main_rc = [
     "Truck_F", 50,
     "Ship", 50,
     "Helicopter", 9999,
-    "Car", 35
+    "Car", 35,
+    "Lamps_base_F", 3
 ];
 btc_log_def_cc = [
     "Land_CargoBox_V1_F", 0,


### PR DESCRIPTION
- FIX: Double portable lamp cannot be removed at logistics point, its says: no object to remove found
I don't know if its the best way to solve this issue, I only tried to remove the double lamp, but it will probably allow deleting other lamps so maybe its not the desired behavior.

**When merged this pull request will:**
- Add `Lamps_base_F` class to the `btc_log_main_rc` class array

**Final test:**
- [x] local
- [x] server
