### PR TITLE
FIX: Remove persistence of objects created by chemical leak side mission

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/chemicalLeak.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/chemicalLeak.sqf
@@ -150,6 +150,7 @@ for "_i" from 1 to (5 + round random 5) do {
         btc_chem_contaminated pushBack _hazmat;
         publicVariable "btc_chem_contaminated";
     };
+    btc_log_obj_created deleteAt (btc_log_obj_created find _hazmat);
 };
 
 private _bring_taskID = _taskID + "br";


### PR DESCRIPTION
- FIX: Remove persistence of objects created by chemical leak side mission (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server