### PR TITLE
Add: Redeploy from FOB to base, separate BI Redeploy and H&M Redeploy

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -349,6 +349,7 @@ btc_fob_mat = "Land_Cargo20_blue_F";
 btc_fob_structure = "Land_Cargo_HQ_V1_F";
 btc_fob_flag = "Flag_NATO_F";
 btc_fob_id = 0;
+btc_fob_minDistance = 1500;
 
 //IED
 btc_type_ieds_ace = ["IEDLandBig_F", "IEDLandSmall_F"];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -13,6 +13,7 @@ btc_p_db_autoRestartTime = "btc_p_db_autoRestartTime" call BIS_fnc_getParamValue
 
 //<< Respawn options >>
 btc_p_respawn_location = "btc_p_respawn_location" call BIS_fnc_getParamValue;
+btc_p_respawn_fromFOBToBase = ("btc_p_respawn_fromFOBToBase" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_rallypointTimer = "btc_p_rallypointTimer" call BIS_fnc_getParamValue;
 btc_p_respawn_arsenal = ("btc_p_respawn_arsenal" call BIS_fnc_getParamValue) isEqualTo 1;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -53,6 +53,12 @@ class Params {
         texts[]={$STR_BTC_HAM_RESP_FOBRALLY, $STR_BTC_HAM_RESP_FOBRALLYHELO, $STR_BTC_HAM_RESP_FOBRALLYHELI, $STR_BTC_HAM_RESP_FOBRALLYHELIVEHI};
         default = 0;
     };
+    class btc_p_respawn_fromFOBToBase { // Allow respawn from FOB to base:
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_RESP_FOBTOBASE"]);
+        values[]={0,1};
+        texts[]={$STR_DISABLED, $STR_ENABLED};
+        default = 0;
+    };
     class btc_p_rallypointTimer { // Time before rallypoint self-destruction:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_RESP_RALLYTIMER"]);
         values[]={0,5,10,30,60};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -294,6 +294,8 @@ if (!isDedicated) then {
     btc_fnc_fob_create = compile preprocessFileLineNumbers "core\fnc\fob\create.sqf";
     btc_fnc_fob_rallypointAssemble = compile preprocessFileLineNumbers "core\fnc\fob\rallypointAssemble.sqf";
     btc_fnc_fob_redeploy = compile preprocessFileLineNumbers "core\fnc\fob\redeploy.sqf";
+    btc_fnc_fob_redeploy = compile preprocessFileLineNumbers "core\fnc\fob\redeploy.sqf";
+    btc_fnc_fob_redeployCheck = compile preprocessFileLineNumbers "core\fnc\fob\redeployCheck.sqf";
 
     //INT
     btc_fnc_int_add_actions = compile preprocessFileLineNumbers "core\fnc\int\add_actions.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/add_veh.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/add_veh.sqf
@@ -43,7 +43,7 @@ if (btc_p_respawn_location > 1) then {
             (btc_p_respawn_location isEqualTo 2) && (_veh isKindOf "Air") ||
             btc_p_respawn_location > 2
         ) then {
-            [missionNamespace, _veh] call BIS_fnc_addRespawnPosition;
+            [btc_player_side, _veh] call BIS_fnc_addRespawnPosition;
         };
     };
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_add_respawn.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_add_respawn.sqf
@@ -44,7 +44,7 @@ if ((isNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "ace_fastroping
 _vehicle addMPEventHandler ["MPKilled", {if (isServer) then {[_this select 0] call btc_fnc_eh_veh_respawn};}];
 if (btc_p_respawn_location > 0) then {
     if !(fullCrew [_vehicle, "cargo", true] isEqualTo []) then {
-        [missionNamespace, _vehicle] call BIS_fnc_addRespawnPosition;
+        [btc_player_side, _vehicle] call BIS_fnc_addRespawnPosition;
     };
 };
 if (_p_chem) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/create.sqf
@@ -26,7 +26,7 @@ params [
 
 if (((position _mat) isFlatEmpty [1, 0, 0.9, 1, 0, false, _mat]) isEqualTo []) exitWith {(localize "STR_BTC_HAM_O_FOB_CREATE_H_AREA") call CBA_fnc_notify;};
 
-if (_mat inArea [getMarkerPos "btc_base", 2000, 2000, 0, false]) exitWith {(localize "STR_BTC_HAM_O_FOB_CREATE_H_DBASE") call CBA_fnc_notify;};
+if (_mat inArea [getMarkerPos "btc_base", btc_fob_minDistance, btc_fob_minDistance, 0, false]) exitWith {(localize "STR_BTC_HAM_O_FOB_CREATE_H_DBASE") call CBA_fnc_notify;};
 
 if ((nearestObjects [position _mat, ["LandVehicle", "Air"], 10]) findIf {!(_x isKindOf "ace_fastroping_helper")} != -1) exitWith {
     (format [localize "STR_BTC_HAM_O_FOB_CREATE_H_CAREA", (nearestObjects [position _mat, ["LandVehicle", "Air"], 10]) apply {typeOf _x}]) call CBA_fnc_notify

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/create_s.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/create_s.sqf
@@ -50,7 +50,7 @@ _marker setMarkerShape "ICON";
 (_fobs select 0) pushBack _marker;
 (_fobs select 1) pushBack _structure;
 (_fobs select 2) pushBack _flag;
-_flag setVariable ["BIS_fnc_IDRespawnPosition", ([missionNamespace, _flag, _FOB_name] call BIS_fnc_addRespawnPosition) select 1];
+_flag setVariable ["BIS_fnc_IDRespawnPosition", ([btc_player_side, _flag, _FOB_name] call BIS_fnc_addRespawnPosition) select 1];
 
 _structure addEventHandler ["Killed", btc_fnc_fob_killed];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/killed.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/killed.sqf
@@ -41,7 +41,7 @@ if (btc_debug || btc_debug_log) then {
     [format ["named %1", (_fobs select 0) select _fob_index], __FILE__, [btc_debug, btc_debug_log]] call btc_fnc_debug_message;
 };
 
-[missionNamespace, ((_fobs select 2) select _fob_index) getVariable "BIS_fnc_IDRespawnPosition"] call BIS_fnc_removeRespawnPosition;
+[btc_player_side, ((_fobs select 2) select _fob_index) getVariable "BIS_fnc_IDRespawnPosition"] call BIS_fnc_removeRespawnPosition;
 deleteMarker ((_fobs select 0) deleteAt _fob_index);
 private _fob = (_fobs select 1) deleteAt _fob_index;
 deleteVehicle ((_fobs select 2) deleteAt _fob_index);

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
@@ -36,21 +36,28 @@ private _childStatement = {
     if ([] call btc_fnc_fob_redeployCheck) then {[_player, _params, false] call BIS_fnc_moveToRespawnPosition};
 };
 
-if (_params isEqualType "") then { // Redeploy on marker like rallypoints
+if (_params isEqualTo "") then { // Redeploy on marker like rallypoints
     {
         private _action = [markerText _x, markerText _x, "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", _childStatement, {true}, {}, _x] call ace_interact_menu_fnc_createAction;
         _actions pushBack [_action, [], _target];
     } forEach (([btc_player_side, false] call BIS_fnc_getRespawnMarkers) - [btc_respawn_marker]);
 } else { // Redeploy on object like FOB/Vehicles
-    private _center = [worldSize / 2, worldsize / 2, 0];
-    _params params ["_min", "_max"];
-    private _positions = (btc_player_side call BIS_fnc_getRespawnPositions) select {
-        if (alive _x) then {
-            private _dir = _center getDir _x;
-            _min <= _dir &&
-            {_dir < _max}
-        } else {
-            false
+    private _getRespawnPositions = btc_player_side call BIS_fnc_getRespawnPositions;
+    private _positions = if (_params isEqualTo "Base") then {
+        _getRespawnPositions inAreaArray [getMarkerPos "btc_base", btc_fob_minDistance, btc_fob_minDistance]
+    } else {
+        private _center = [worldSize / 2, worldsize / 2, 0];
+        _params params ["_min", "_max"];
+        _getRespawnPositions select {
+            if (
+                alive _x && {!(_x inArea [getMarkerPos "btc_base", btc_fob_minDistance, btc_fob_minDistance, 0, false])}
+            ) then {
+                private _dir = _center getDir _x;
+                _min <= _dir &&
+                {_dir < _max}
+            } else {
+                false
+            };
         };
     };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
@@ -33,32 +33,33 @@ private _actions = [];
 private _childStatement = {
     params ["_target", "_player", "_params"];
 
-    [_player, _params] call BIS_fnc_moveToRespawnPosition;
+    if ([] call btc_fnc_fob_redeployCheck) then {[_player, _params, false] call BIS_fnc_moveToRespawnPosition};
 };
 
-if (_params isEqualType "") exitWith { // Redeploy on marker like rallypoints
+if (_params isEqualType "") then { // Redeploy on marker like rallypoints
     {
         private _action = [markerText _x, markerText _x, "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", _childStatement, {true}, {}, _x] call ace_interact_menu_fnc_createAction;
         _actions pushBack [_action, [], _target];
     } forEach (([btc_player_side, false] call BIS_fnc_getRespawnMarkers) - [btc_respawn_marker]);
+} else { // Redeploy on object like FOB/Vehicles
+    private _center = [worldSize / 2, worldsize / 2, 0];
+    _params params ["_min", "_max"];
+    private _positions = (btc_player_side call BIS_fnc_getRespawnPositions) select {
+        if (alive _x) then {
+            private _dir = _center getDir _x;
+            _min <= _dir &&
+            {_dir < _max}
+        } else {
+            false
+        };
+    };
 
-    _actions
+    {
+        private ["_identity", "_name", "_pic", "_showName", "_respawnPositions", "_respawnPositionNames", "_respawnPositionNameShow", "_pos"];
+        (_x call BIS_fnc_showRespawnMenuPositionName) params ["_FOBName", "_icon"];
+        private _action = [_FOBName, _FOBName, _icon, _childStatement, {true}, {}, _x] call ace_interact_menu_fnc_createAction;
+        _actions pushBack [_action, [], _target];
+    } forEach _positions;
 };
-
-// Redeploy on object like FOB/Vehicles
-private _center = [worldSize / 2, worldsize / 2, 0];
-_params params ["_min", "_max"];
-private _positions = (btc_player_side call BIS_fnc_getRespawnPositions) select {
-    private _dir = _center getDir _x;
-    _min < _dir &&
-    {_dir < _max}
-};
-
-{
-    private ["_identity", "_name", "_pic", "_showName", "_respawnPositions", "_respawnPositionNames", "_respawnPositionNameShow", "_pos"];
-    (_x call BIS_fnc_showRespawnMenuPositionName) params ["_FOBName", "_icon"];
-    private _action = [_FOBName, _FOBName, _icon, _childStatement, {true}, {}, _x] call ace_interact_menu_fnc_createAction;
-    _actions pushBack [_action, [], _target];
-} forEach (_positions);
 
 _actions

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
@@ -3,15 +3,15 @@
 Function: btc_fnc_fob_redeploy
 
 Description:
-    Create child statement to reploy.
+    Create child statement to redeploy.
 
 Parameters:
-    _target - is the object being interacted with. [Object]
-    _player - is ace_player. [Object]
-    _params - is the optional action parameters. (default [])
+    _target - Is the object being interacted with. [Object]
+    _player - Is ace_player. [Object]
+    _params - Is the optional action parameters. (default [])
 
 Returns:
-    _actions - Action generated for redeploy. [Boolean]
+    _actions - ACE action generated for redeploy. [Boolean]
 
 Examples:
     (begin example)

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
@@ -3,11 +3,15 @@
 Function: btc_fnc_fob_redeploy
 
 Description:
-    Show A3 respawn menu.
+    Create child statement to reploy.
 
 Parameters:
+    _target - is the object being interacted with. [Object]
+    _player - is ace_player. [Object]
+    _params - is the optional action parameters. (default [])
 
 Returns:
+    _actions - Action generated for redeploy. [Boolean]
 
 Examples:
     (begin example)
@@ -19,19 +23,42 @@ Author:
 
 ---------------------------------------------------------------------------- */
 
-if !(player call ace_medical_status_fnc_isInStableCondition) exitWith {
-    [[localize "STR_BTC_HAM_O_FOB_CANTREPLOY"], [localize "STR_BTC_HAM_O_FOB_REPLOYNOTSTABLE"]] call CBA_fnc_notify;
+params [
+    "_target",
+    "_player",
+    "_params"
+];
+
+private _actions = [];
+private _childStatement = {
+    params ["_target", "_player", "_params"];
+
+    [_player, _params] call BIS_fnc_moveToRespawnPosition;
 };
 
-if (
-    ["leftarm", "rightarm", "leftleg", "rightleg"] findIf {
-        [player, player, _x] call ace_medical_treatment_fnc_canSplint
-    } > -1
-) exitWith {
-    [[localize "STR_BTC_HAM_O_FOB_CANTREPLOY"], [localize "STR_BTC_HAM_O_FOB_REPLOYSPLINT"]] call CBA_fnc_notify;
+if (_params isEqualType "") exitWith { // Redeploy on marker like rallypoints
+    {
+        private _action = [markerText _x, markerText _x, "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", _childStatement, {true}, {}, _x] call ace_interact_menu_fnc_createAction;
+        _actions pushBack [_action, [], _target];
+    } forEach (([btc_player_side, false] call BIS_fnc_getRespawnMarkers) - [btc_respawn_marker]);
+
+    _actions
 };
 
-player setPos [10, 10, 10];
-player hideObject true;
-player enableSimulation false;
-forceRespawn player;
+// Redeploy on object like FOB/Vehicles
+private _center = [worldSize / 2, worldsize / 2, 0];
+_params params ["_min", "_max"];
+private _positions = (btc_player_side call BIS_fnc_getRespawnPositions) select {
+    private _dir = _center getDir _x;
+    _min < _dir &&
+    {_dir < _max}
+};
+
+{
+    private ["_identity", "_name", "_pic", "_showName", "_respawnPositions", "_respawnPositionNames", "_respawnPositionNameShow", "_pos"];
+    (_x call BIS_fnc_showRespawnMenuPositionName) params ["_FOBName", "_icon"];
+    private _action = [_FOBName, _FOBName, _icon, _childStatement, {true}, {}, _x] call ace_interact_menu_fnc_createAction;
+    _actions pushBack [_action, [], _target];
+} forEach (_positions);
+
+_actions

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeployCheck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeployCheck.sqf
@@ -21,7 +21,7 @@ Author:
 ---------------------------------------------------------------------------- */
 
 if !(player call ace_medical_status_fnc_isInStableCondition) exitWith {
-    [[localize "STR_BTC_HAM_O_FOB_CANTREPLOY"], [localize "STR_BTC_HAM_O_FOB_REPLOYNOTSTABLE"]] call CBA_fnc_notify;
+    [[localize "STR_BTC_HAM_O_FOB_CANTREDEPLOY"], [localize "STR_BTC_HAM_O_FOB_REDEPLOYNOTSTABLE"]] call CBA_fnc_notify;
     false
 };
 
@@ -30,7 +30,7 @@ if (
         [player, player, _x] call ace_medical_treatment_fnc_canSplint
     } > -1
 ) exitWith {
-    [[localize "STR_BTC_HAM_O_FOB_CANTREPLOY"], [localize "STR_BTC_HAM_O_FOB_REPLOYSPLINT"]] call CBA_fnc_notify;
+    [[localize "STR_BTC_HAM_O_FOB_CANTREDEPLOY"], [localize "STR_BTC_HAM_O_FOB_REDEPLOYSPLINT"]] call CBA_fnc_notify;
     false
 };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeployCheck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/fob/redeployCheck.sqf
@@ -1,0 +1,37 @@
+
+/* ----------------------------------------------------------------------------
+Function: btc_fnc_fob_redeployCheck
+
+Description:
+    Check if player can redeploy.
+
+Parameters:
+
+Returns:
+    _canRedeploy - Can redeploy. [Boolean]
+
+Examples:
+    (begin example)
+        [] call btc_fnc_fob_redeployCheck;
+    (end)
+
+Author:
+    Vdauphin
+
+---------------------------------------------------------------------------- */
+
+if !(player call ace_medical_status_fnc_isInStableCondition) exitWith {
+    [[localize "STR_BTC_HAM_O_FOB_CANTREPLOY"], [localize "STR_BTC_HAM_O_FOB_REPLOYNOTSTABLE"]] call CBA_fnc_notify;
+    false
+};
+
+if (
+    ["leftarm", "rightarm", "leftleg", "rightleg"] findIf {
+        [player, player, _x] call ace_medical_treatment_fnc_canSplint
+    } > -1
+) exitWith {
+    [[localize "STR_BTC_HAM_O_FOB_CANTREPLOY"], [localize "STR_BTC_HAM_O_FOB_REPLOYSPLINT"]] call CBA_fnc_notify;
+    false
+};
+
+true

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -138,7 +138,7 @@ _actions pushBack ["redeploy", localize "STR_BTC_HAM_ACTION_BIRESPAWN", "\A3\ui_
 }, {!btc_log_placing}];
 _actions pushBack ["base", localize "STR_BTC_HAM_ACTION_REDEPLOYBASE", getText (configfile >> "CfgMarkers" >> getMarkerType "btc_base" >> "icon"), {
     if ([] call btc_fnc_fob_redeployCheck) then {[_player, btc_respawn_marker, false] call BIS_fnc_moveToRespawnPosition};
-}, {!btc_log_placing}];
+}, {!btc_log_placing}, {_this call btc_fnc_fob_redeploy}, "Base"];
 _actions pushBack ["rallypoints", localize "STR_BTC_HAM_ACTION_REDEPLOYRALLY", "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", {}, {!btc_log_placing}, {_this call btc_fnc_fob_redeploy}, ""];
 _actions pushBack ["FOB", localize "STR_BTC_HAM_ACTION_REDEPLOYFOB", "\A3\Ui_f\data\Map\Markers\NATO\b_hq.paa", {}, {!btc_log_placing}];
 {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -127,12 +127,54 @@ if (btc_debug) then {
 };
 
 //Re-deploy
-_action = ["fob_redeploy", localize "STR_BTC_HAM_ACTION_REDEPLOY_MAIN", "\A3\ui_f\data\igui\cfg\simpleTasks\types\run_ca.paa", {[] call btc_fnc_fob_redeploy;}, {!btc_log_placing}, {}, [], [0.4, 0, 0.4], 5] call ace_interact_menu_fnc_createAction;
+_action = ["redeploy", "BI re-deploy", "\A3\ui_f\data\igui\cfg\simpleTasks\types\run_ca.paa", {[] call btc_fnc_fob_redeploy;}, {!btc_log_placing}, {}, [], [0.4, 0, 0.4], 5] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+_action = ["base", "Re-deploy base", "", {_player setPosATL getMarkerPos [btc_respawn_marker, true];}, {!btc_log_placing}] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+_insertChildren = {
+    params ["_target", "_player", "_params"];
+
+    private _actions = [];
+    {
+        private _childStatement = {
+            params ["_target", "_player", "_params"];
+
+            _player setPosATL getMarkerPos [_params, true];
+        };
+        private _action = [markerText _x, markerText _x, "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", _childStatement, {true}, {}, _x] call ace_interact_menu_fnc_createAction;
+        _actions pushBack [_action, [], _target];
+    } forEach (([btc_player_side, false] call BIS_fnc_getRespawnMarkers) - [btc_respawn_marker]);
+
+    _actions
+};
+_action = ["rallypoints", "Re-deploy rallypoints", "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", {}, {!btc_log_placing}, _insertChildren] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+_insertChildren = {
+    params ["_target", "_player", "_params"];
+
+    private _actions = [];
+    {
+        private _childStatement = {
+            params ["_target", "_player", "_params"];
+
+            _player setPosATL getPosATL _params;
+        };
+        private ["_identity", "_name", "_pic", "_showName", "_respawnPositions", "_respawnPositionNames", "_respawnPositionNameShow", "_pos"];
+        (_x call BIS_fnc_showRespawnMenuPositionName) params ["_FOBName", "_icon"];
+        private _action = [_FOBName, _FOBName, _icon, _childStatement, {true}, {}, _x] call ace_interact_menu_fnc_createAction;
+        _actions pushBack [_action, [], _target];
+    } forEach (btc_player_side call BIS_fnc_getRespawnPositions);
+
+    _actions
+};
+_action = ["FOB", "Redeploy FOB/vehicles", "\A3\Ui_f\data\Map\Markers\NATO\b_hq.paa", {}, {!btc_log_placing}, _insertChildren] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+
+/*
 if (true) then {
   [btc_fob_flag, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToClass;
 };
-
+*/
 //Arsenal
 //BIS
 if (btc_p_arsenal_Type < 3) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -127,48 +127,29 @@ if (btc_debug) then {
 };
 
 //Re-deploy
-_action = ["redeploy", "BI re-deploy", "\A3\ui_f\data\igui\cfg\simpleTasks\types\run_ca.paa", {[] call btc_fnc_fob_redeploy;}, {!btc_log_placing}, {}, [], [0.4, 0, 0.4], 5] call ace_interact_menu_fnc_createAction;
+_action = ["redeploy", "BI re-deploy", "\A3\ui_f\data\igui\cfg\simpleTasks\types\run_ca.paa", {
+    if ([] call btc_fnc_fob_redeployCheck) then {
+        player setPos [10, 10, 10];
+        player hideObject true;
+        player enableSimulation false;
+        forceRespawn player;
+    };
+}, {!btc_log_placing}, {}, [], [0.4, 0, 0.4], 5] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
 _action = ["base", "Re-deploy base", "", {_player setPosATL getMarkerPos [btc_respawn_marker, true];}, {!btc_log_placing}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_insertChildren = {
-    params ["_target", "_player", "_params"];
-
-    private _actions = [];
-    {
-        private _childStatement = {
-            params ["_target", "_player", "_params"];
-
-            _player setPosATL getMarkerPos [_params, true];
-        };
-        private _action = [markerText _x, markerText _x, "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", _childStatement, {true}, {}, _x] call ace_interact_menu_fnc_createAction;
-        _actions pushBack [_action, [], _target];
-    } forEach (([btc_player_side, false] call BIS_fnc_getRespawnMarkers) - [btc_respawn_marker]);
-
-    _actions
-};
-_action = ["rallypoints", "Re-deploy rallypoints", "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", {}, {!btc_log_placing}, _insertChildren] call ace_interact_menu_fnc_createAction;
+_action = ["rallypoints", "Re-deploy rallypoints", "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", {}, {!btc_log_placing}, {_this call btc_fnc_fob_redeploy}, ""] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_insertChildren = {
-    params ["_target", "_player", "_params"];
-
-    private _actions = [];
-    {
-        private _childStatement = {
-            params ["_target", "_player", "_params"];
-
-            _player setPosATL getPosATL _params;
-        };
-        private ["_identity", "_name", "_pic", "_showName", "_respawnPositions", "_respawnPositionNames", "_respawnPositionNameShow", "_pos"];
-        (_x call BIS_fnc_showRespawnMenuPositionName) params ["_FOBName", "_icon"];
-        private _action = [_FOBName, _FOBName, _icon, _childStatement, {true}, {}, _x] call ace_interact_menu_fnc_createAction;
-        _actions pushBack [_action, [], _target];
-    } forEach (btc_player_side call BIS_fnc_getRespawnPositions);
-
-    _actions
-};
-_action = ["FOB", "Redeploy FOB/vehicles", "\A3\Ui_f\data\Map\Markers\NATO\b_hq.paa", {}, {!btc_log_placing}, _insertChildren] call ace_interact_menu_fnc_createAction;
+_action = ["FOB", "Redeploy FOB/vehicles", "\A3\Ui_f\data\Map\Markers\NATO\b_hq.paa", {}, {!btc_log_placing}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+_action = ["FOB NE", "NE", "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, [0, 90]] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;
+_action = ["FOB SE", "SE", "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, [90, 180]] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;
+_action = ["FOB SW", "SW", "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, [180, 270]] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;
+_action = ["FOB NW", "NW", "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, [270, 360]] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;
 
 /*
 if (true) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -129,6 +129,9 @@ if (btc_debug) then {
 //Re-deploy
 _action = ["fob_redeploy", localize "STR_BTC_HAM_ACTION_REDEPLOY_MAIN", "\A3\ui_f\data\igui\cfg\simpleTasks\types\run_ca.paa", {[] call btc_fnc_fob_redeploy;}, {!btc_log_placing}, {}, [], [0.4, 0, 0.4], 5] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+if (true) then {
+  [btc_fob_flag, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToClass;
+};
 
 //Arsenal
 //BIS

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -128,7 +128,7 @@ if (btc_debug) then {
 
 //Re-deploy
 private _actions = [];
-_actions pushBack ["redeploy", localize "STR_BTC_HAM_ACTION_BIREDEPLOY", "\A3\ui_f\data\igui\cfg\simpleTasks\types\run_ca.paa", {
+_actions pushBack ["redeploy", localize "STR_BTC_HAM_ACTION_BIRESPAWN", "\A3\ui_f\data\igui\cfg\simpleTasks\types\run_ca.paa", {
     if ([] call btc_fnc_fob_redeployCheck) then {
         player setPos [10, 10, 10];
         player hideObject true;
@@ -151,12 +151,12 @@ _actions pushBack ["FOB", localize "STR_BTC_HAM_ACTION_REDEPLOYFOB", "\A3\Ui_f\d
 {
     _x params ["_cardinal", "_degrees"];
 
-    _action = ["FOB" + _cardinal, _cardinal, "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, _degrees] call ace_interact_menu_fnc_createAction;
+    _action = ["FOB" + _cardinal, localize _cardinal, "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, _degrees] call ace_interact_menu_fnc_createAction;
     [btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;
     if (btc_p_respawn_fromFOBToBase) then {
         [btc_fob_flag, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToClass;
     };
-} forEach [[localize "str_q_north_east", [0, 90]], [localize "str_q_south_east", [90, 180]], [localize "str_q_south_west", [180, 270]], [localize "str_q_north_west", [270, 360]]];
+} forEach [["str_q_north_east", [0, 90]], ["str_q_south_east", [90, 180]], ["str_q_south_west", [180, 270]], ["str_q_north_west", [270, 360]]];
 
 //Arsenal
 //BIS

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -127,37 +127,37 @@ if (btc_debug) then {
 };
 
 //Re-deploy
-_action = ["redeploy", "BI re-deploy", "\A3\ui_f\data\igui\cfg\simpleTasks\types\run_ca.paa", {
+private _actions = [];
+_actions pushBack ["redeploy", localize "STR_BTC_HAM_ACTION_BIREDEPLOY", "\A3\ui_f\data\igui\cfg\simpleTasks\types\run_ca.paa", {
     if ([] call btc_fnc_fob_redeployCheck) then {
         player setPos [10, 10, 10];
         player hideObject true;
         player enableSimulation false;
         forceRespawn player;
     };
-}, {!btc_log_placing}, {}, [], [0.4, 0, 0.4], 5] call ace_interact_menu_fnc_createAction;
-[btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["base", "Re-deploy base", getText (configfile >> "CfgMarkers" >> getMarkerType "btc_base" >> "icon"), {
+}, {!btc_log_placing}];
+_actions pushBack ["base", localize "STR_BTC_HAM_ACTION_REDEPLOYBASE", getText (configfile >> "CfgMarkers" >> getMarkerType "btc_base" >> "icon"), {
     if ([] call btc_fnc_fob_redeployCheck) then {[_player, btc_respawn_marker, false] call BIS_fnc_moveToRespawnPosition};
-}, {!btc_log_placing}] call ace_interact_menu_fnc_createAction;
-[btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["rallypoints", "Re-deploy rallypoints", "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", {}, {!btc_log_placing}, {_this call btc_fnc_fob_redeploy}, ""] call ace_interact_menu_fnc_createAction;
-[btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["FOB", "Re-deploy FOB/vehicles", "\A3\Ui_f\data\Map\Markers\NATO\b_hq.paa", {}, {!btc_log_placing}] call ace_interact_menu_fnc_createAction;
-[btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["FOB NE", "NE", "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, [0, 90]] call ace_interact_menu_fnc_createAction;
-[btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["FOB SE", "SE", "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, [90, 180]] call ace_interact_menu_fnc_createAction;
-[btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["FOB SW", "SW", "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, [180, 270]] call ace_interact_menu_fnc_createAction;
-[btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["FOB NW", "NW", "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, [270, 360]] call ace_interact_menu_fnc_createAction;
-[btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;
+}, {!btc_log_placing}];
+_actions pushBack ["rallypoints", localize "STR_BTC_HAM_ACTION_REDEPLOYRALLY", "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", {}, {!btc_log_placing}, {_this call btc_fnc_fob_redeploy}, ""];
+_actions pushBack ["FOB", localize "STR_BTC_HAM_ACTION_REDEPLOYFOB", "\A3\Ui_f\data\Map\Markers\NATO\b_hq.paa", {}, {!btc_log_placing}];
+{
+    private _action = _x call ace_interact_menu_fnc_createAction;
+    [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+    if (btc_p_respawn_fromFOBToBase) then {
+        [btc_fob_flag, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToClass;
+    };
+} forEach _actions;
+{
+    _x params ["_cardinal", "_degrees"];
 
-/*
-if (true) then {
-  [btc_fob_flag, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToClass;
-};
-*/
+    _action = ["FOB" + _cardinal, _cardinal, "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, _degrees] call ace_interact_menu_fnc_createAction;
+    [btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;
+    if (btc_p_respawn_fromFOBToBase) then {
+        [btc_fob_flag, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToClass;
+    };
+} forEach [[localize "str_q_north_east", [0, 90]], [localize "str_q_south_east", [90, 180]], [localize "str_q_south_west", [180, 270]], [localize "str_q_north_west", [270, 360]]];
+
 //Arsenal
 //BIS
 if (btc_p_arsenal_Type < 3) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -136,11 +136,13 @@ _action = ["redeploy", "BI re-deploy", "\A3\ui_f\data\igui\cfg\simpleTasks\types
     };
 }, {!btc_log_placing}, {}, [], [0.4, 0, 0.4], 5] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["base", "Re-deploy base", "", {_player setPosATL getMarkerPos [btc_respawn_marker, true];}, {!btc_log_placing}] call ace_interact_menu_fnc_createAction;
+_action = ["base", "Re-deploy base", getText (configfile >> "CfgMarkers" >> getMarkerType "btc_base" >> "icon"), {
+    if ([] call btc_fnc_fob_redeployCheck) then {[_player, btc_respawn_marker, false] call BIS_fnc_moveToRespawnPosition};
+}, {!btc_log_placing}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
 _action = ["rallypoints", "Re-deploy rallypoints", "\A3\ui_f\data\igui\cfg\simpleTasks\types\wait_ca.paa", {}, {!btc_log_placing}, {_this call btc_fnc_fob_redeploy}, ""] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["FOB", "Redeploy FOB/vehicles", "\A3\Ui_f\data\Map\Markers\NATO\b_hq.paa", {}, {!btc_log_placing}] call ace_interact_menu_fnc_createAction;
+_action = ["FOB", "Re-deploy FOB/vehicles", "\A3\Ui_f\data\Map\Markers\NATO\b_hq.paa", {}, {!btc_log_placing}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
 _action = ["FOB NE", "NE", "\A3\ui_f\data\igui\cfg\simpleTasks\types\map_ca.paa", {}, {true}, {_this call btc_fnc_fob_redeploy}, [0, 90]] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "FOB"], _action] call ace_interact_menu_fnc_addActionToObject;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -465,6 +465,9 @@
                 <Original>Respawn locations available:</Original>
                 <Chinesesimp>可用的重生位置</Chinesesimp>
             </Key>
+            <Key ID="STR_BTC_HAM_RESP_FOBTOBASE">
+                <Original>Allow respawn from FOB to base:</Original>
+            </Key>
             <Key ID="STR_BTC_HAM_RESP_FOBRALLY">
                 <Original>FOB and Rallypoint</Original>
                 <Chinesesimp>FOB 和 集合点</Chinesesimp>
@@ -1386,12 +1389,21 @@
             </Key>
         </Container>
         <Container name="Action(ACE): Re-deploy">
-            <Key ID="STR_BTC_HAM_ACTION_REDEPLOY_MAIN">
-                <Original>Re-deploy</Original>
-                <Spanish>Re-deploy</Spanish>
-                <German>Verlegen</German>
-                <Portuguese>Ressurgir na FOB</Portuguese>
-                <Chinesesimp>重新部署</Chinesesimp>
+            <Key ID="STR_BTC_HAM_ACTION_BIREDEPLOY">
+                <Original>BI Re-deploy</Original>
+                <Spanish>BI Re-deploy</Spanish>
+                <German>BI Verlegen</German>
+                <Portuguese>BI Ressurgir na FOB</Portuguese>
+                <Chinesesimp>BI 重新部署</Chinesesimp>
+            </Key>
+            <Key ID="STR_BTC_HAM_ACTION_REDEPLOYBASE">
+                <Original>Re-deploy base</Original>
+            </Key>
+            <Key ID="STR_BTC_HAM_ACTION_REDEPLOYRALLY">
+                <Original>Re-deploy rallypoints</Original>
+            </Key>
+            <Key ID="STR_BTC_HAM_ACTION_REDEPLOYFOB">
+                <Original>Re-deploy FOB/vehicles</Original>
             </Key>
         </Container>
         <Container name="Action : Arsenal (BIS)">

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -1389,12 +1389,8 @@
             </Key>
         </Container>
         <Container name="Action(ACE): Re-deploy">
-            <Key ID="STR_BTC_HAM_ACTION_BIREDEPLOY">
-                <Original>BI Re-deploy</Original>
-                <Spanish>BI Re-deploy</Spanish>
-                <German>BI Verlegen</German>
-                <Portuguese>BI Ressurgir na FOB</Portuguese>
-                <Chinesesimp>BI 重新部署</Chinesesimp>
+            <Key ID="STR_BTC_HAM_ACTION_BIRESPAWN">
+                <Original>BI respawn</Original>
             </Key>
             <Key ID="STR_BTC_HAM_ACTION_REDEPLOYBASE">
                 <Original>Re-deploy base</Original>
@@ -1745,15 +1741,15 @@
                 <Original>This rallypoint will self-destruct in %1min.</Original>
                 <Chinesesimp>该集合点将在 %1 分钟后自毁。</Chinesesimp>
             </Key>
-            <Key ID="STR_BTC_HAM_O_FOB_CANTREPLOY">
+            <Key ID="STR_BTC_HAM_O_FOB_CANTREDEPLOY">
                 <Original>Can't redeploy,</Original>
                 <Chinesesimp>无法重新部署, </Chinesesimp>
             </Key>
-            <Key ID="STR_BTC_HAM_O_FOB_REPLOYNOTSTABLE">
+            <Key ID="STR_BTC_HAM_O_FOB_REDEPLOYNOTSTABLE">
                 <Original>you need to be stabilized</Original>
                 <Chinesesimp>需要稳定伤势</Chinesesimp>
             </Key>
-            <Key ID="STR_BTC_HAM_O_FOB_REPLOYSPLINT">
+            <Key ID="STR_BTC_HAM_O_FOB_REDEPLOYSPLINT">
                 <Original>you need to have a splint</Original>
                 <Chinesesimp>需要佩戴固定夹板</Chinesesimp>
             </Key>


### PR DESCRIPTION
- Add: Option to redeploy from FOB to base (@Vdauphin).
- Add: Separate BI respawn and H&M redeploy (@Vdauphin).

**When merged this pull request will:**
- title
- https://github.com/Vdauphin/HeartsAndMinds/issues/738

**Final test:**
- [x] local
- [x] server

**Screenshot:**
![20200606141057_1](https://user-images.githubusercontent.com/14364400/83945496-54db8280-a80b-11ea-8e24-a65ef093994a.jpg)
![20200606141121_1](https://user-images.githubusercontent.com/14364400/83945497-560caf80-a80b-11ea-9fbb-8556dc105e7d.jpg)
![20200606150231_1](https://user-images.githubusercontent.com/14364400/83945498-56a54600-a80b-11ea-8c2f-e4bc0250a067.jpg)
![20200606153849_1](https://user-images.githubusercontent.com/14364400/83945559-dc28f600-a80b-11ea-87d1-7de3df804512.jpg)