### PR TITLE
FIX: FOB height not restored when loading saved game

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
@@ -127,7 +127,7 @@ profileNamespace setVariable [format ["btc_hm_%1_rep", _name], btc_global_reputa
 private _fobs = [];
 {
     if !(isNull ((btc_fobs select 2) select _forEachIndex)) then {
-        private _pos = getMarkerPos _x;
+        private _pos = getMarkerPos [_x, true];
         private _direction = getDir ((btc_fobs select 1) select _forEachIndex);
         _fobs pushBack [markerText _x, _pos, _direction];
     };


### PR DESCRIPTION
- FIX: FOB height not restored when loading saved game (@Vdauphin).

**When merged this pull request will:**
- title
- fix #899 

**Final test:**
- [x] local
- [x] server