### PR TITLE
FIX: Killed-event handler can run twice for the same entity in some cases

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/add_veh.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/add_veh.sqf
@@ -32,7 +32,14 @@ if !(isServer) exitWith {
 
 btc_vehicles pushBackUnique _veh;
 _veh addMPEventHandler ["MPKilled", {
-    if (isServer) then {_this call btc_fnc_eh_veh_killed};
+    params ["_unit"];
+    if (
+        isServer &&
+        {_unit getVariable ["btc_killed", true]} // https://feedback.bistudio.com/T149510
+    ) then {
+        _unit setVariable ["btc_killed", false];
+        _this call btc_fnc_eh_veh_killed;
+    };
 }];
 if ((isNumber (configfile >> "CfgVehicles" >> typeOf _veh >> "ace_fastroping_enabled")) && !(typeOf _veh isEqualTo "RHS_UH1Y_d")) then {
     [_veh] call ace_fastroping_fnc_equipFRIES

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_add_respawn.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/veh_add_respawn.sqf
@@ -42,7 +42,16 @@ _vehProperties set [5, false];
 _vehicle setVariable ["data_respawn", [_type, _pos, _dir, _time, _vector] + _vehProperties];
 
 if ((isNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "ace_fastroping_enabled")) && !(typeOf _vehicle isEqualTo "RHS_UH1Y_d")) then {[_vehicle] call ace_fastroping_fnc_equipFRIES};
-_vehicle addMPEventHandler ["MPKilled", {if (isServer) then {[_this select 0] call btc_fnc_eh_veh_respawn};}];
+_vehicle addMPEventHandler ["MPKilled", {
+    params ["_unit"];
+    if (
+        isServer &&
+        {_unit getVariable ["btc_killed", true]} // https://feedback.bistudio.com/T149510
+    ) then {
+        _unit setVariable ["btc_killed", false];
+        [_unit] call btc_fnc_eh_veh_respawn;
+    };
+}];
 if (_p_chem) then {
     _vehicle addEventHandler ["GetIn", {
         [_this select 0, _this select 2] call btc_fnc_chem_propagate;


### PR DESCRIPTION
- FIX: Killed-event handler can run twice for the same entity in some cases (@Vdauphin).

**When merged this pull request will:**
- title
- https://github.com/acemod/ACE3/pull/7561
- https://feedback.bistudio.com/T149510 not fixed in 2.00, may be never

**Final test:**
- [x] local
- [x] server