### PR TITLE
FIX: EMP side mission stuck if ammo cache destroyed by non-explosive ammos

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/EMP.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/EMP.sqf
@@ -111,6 +111,8 @@ for "_i" from 0 to (1 + round random 2) do {
             }, [_fx], 120] call CBA_fnc_waitAndExecute;
             btc_spect_emp deleteAt (btc_spect_emp find _box);
             publicVariable "btc_spect_emp";
+        } else {
+            0
         };
     }, [_destroy_taskID]] call CBA_fnc_addBISEventHandler;
 };


### PR DESCRIPTION
- FIX: EMP side mission stuck if ammo cache destroyed by non-explosive ammo (@Vdauphin).

**When merged this pull request will:**
- title
- fix #975 


**Final test:**
- [x] local
- [x] server