### PR TITLE
FIX: Adjust weapon holder clean up distance to match the clean up distance of dead bodys

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/cleanUp.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/cleanUp.sqf
@@ -3,7 +3,7 @@
 Function: btc_fnc_city_cleanUp
 
 Description:
-    Delete all ground weapon holder (in range of 150 m), dead bodies (in range of 500 m) and empty group.
+    Delete all ground weapon holder (in range of 500 m), dead bodies (in range of 500 m) and empty group.
 
 Parameters:
     _playableUnits - Players connected. [Array]
@@ -28,7 +28,7 @@ btc_groundWeaponHolder = btc_groundWeaponHolder - [objNull];
 private _toRemove = ((btc_groundWeaponHolder + (entities "WeaponHolderSimulated")) select {!(_x getVariable ["no_cache", false])}) select {
     private _obj = _x;
 
-    _playableUnits inAreaArray [getPosWorld _obj, 150, 150] isEqualTo []
+    _playableUnits inAreaArray [getPosWorld _obj, 500, 500] isEqualTo []
 };
 
 _toRemove append (allDead select {


### PR DESCRIPTION
- FIX: Adjust weapon holder clean up distance to match the clean up distance of dead bodys.

**When merged this pull request will:**
- Weapons will not be cleared before the body. This leads to strange situations where the dead body is still there but the weapon/launcher disappears.

**Final test:**
- [x] local
- [x] server

