### PR TITLE
FIX: ViV objects are saved twice

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
@@ -171,7 +171,8 @@ private _array_obj = [];
     };
 } forEach (btc_log_obj_created select {
     !(isObjectHidden _x) &&
-    (objectParent _x) isEqualTo objNull
+    isNull objectParent _x &&
+    isNull isVehicleCargo _x
 });
 profileNamespace setVariable [format ["btc_hm_%1_objs", _name], _array_obj];
 


### PR DESCRIPTION
- FIX: ViV objects are saved twice (@Vdauphin).

**When merged this pull request will:**
- title
- since https://github.com/acemod/ACE3/pull/7984

**Final test:**
- [x] local
- [x] server