### PR TITLE
FIX: Number of tags grow when two cities overlapping

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/de_activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/de_activate.sqf
@@ -85,15 +85,17 @@ if !(_city getVariable ["active", false]) exitWith {};
 
     private _data_tags = [];
     {
-        private _pos = getPos _x;
-        _pos set [2, 0];
-        _data_tags pushBack [
-            _pos,
-            [vectorDir _x, vectorUp _x],
-            _x getVariable "btc_texture",
-            typeOf _x
-        ];
-        _x call CBA_fnc_deleteEntity;
+        if (_x getVariable ["btc_city", _city] isEqualTo _city) then {
+            private _pos = getPos _x;
+            _pos set [2, 0];
+            _data_tags pushBack [
+                _pos,
+                [vectorDir _x, vectorUp _x],
+                _x getVariable "btc_texture",
+                typeOf _x
+            ];
+            _x call CBA_fnc_deleteEntity;
+        };
     } forEach (btc_tags_server inAreaArray [_pos_city, _radius, _radius]);
     btc_tags_server = btc_tags_server - [objNull];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tag/eh.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tag/eh.sqf
@@ -24,6 +24,7 @@ params ["_tag", "_texture", "_object", "_unit"];
 
 if (_unit in btc_city_all) then {
     _tag setVariable ["btc_texture", _texture]; //Store texture for city de_activation
+    _tag setVariable ["btc_city", _unit];
     btc_tags_server pushBack _tag;
 } else {
     if (_texture isEqualTo "#(rgb,8,8,3)color(0,0,0,0)") then { //Check if player want to remove a tag


### PR DESCRIPTION
- ignore changelog.

**When merged this pull request will:**
- This attribute tag to a specific city.
- Before when two city was overlaping, just on city store the tag. So each time the second city is activated, it create new tags.

**Final test:**
- [x] local
- [x] server