### PR TITLE
FIX: AI spawn indefinitely when city overlapping

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -100,7 +100,7 @@ if !(_ieds isEqualTo []) then {
 private _delay = 0;
 if !(_data_units isEqualTo []) then {
     {
-        _delay = _delay + ([_x, _id] call btc_fnc_data_spawn_group);
+        _delay = _delay + ([_x, _city] call btc_fnc_data_spawn_group);
     } forEach _data_units;
 } else {
     // Maximum number of enemy group
@@ -133,7 +133,7 @@ if !(_data_units isEqualTo []) then {
                 case "Airport" : {2};
                 default {0};
             });
-            [+_houses, round (_p_mil_static_group_ratio * random _max_number_group)] call btc_fnc_mil_create_staticOnRoof;
+            [+_houses, round (_p_mil_static_group_ratio * random _max_number_group), _city] call btc_fnc_mil_create_staticOnRoof;
         };
 
         // Spawn civilians
@@ -151,7 +151,7 @@ if !(_data_units isEqualTo []) then {
 if (btc_p_animals_group_ratio > 0) then {
     if !(_data_animals isEqualTo []) then {
         {
-            _x call btc_fnc_delay_createAgent;
+            (_x + [nil, _city]) call btc_fnc_delay_createAgent;
         } forEach _data_animals;
     } else {
         // Spawn animals
@@ -168,7 +168,7 @@ if (btc_p_animals_group_ratio > 0) then {
         for "_i" from 1 to (round (random _max_number_animalsGroup)) do {
             private _pos = [_city, _spawningRadius/3] call CBA_fnc_randPos;
             for "_i" from 1 to (round (random 3)) do {
-                [selectRandom btc_animals_type, [_pos, 6] call CBA_fnc_randPos] call btc_fnc_delay_createAgent;
+                [selectRandom btc_animals_type, [_pos, 6] call CBA_fnc_randPos, nil, _city] call btc_fnc_delay_createAgent;
             };
         };
     };
@@ -213,12 +213,12 @@ if (_has_ho && {!(_city getVariable ["ho_units_spawned", false])}) then {
         case (_random <= 0.3) : {};
         case (_random > 0.3 && _random <= 0.75) : {
             private _statics = btc_type_gl + btc_type_mg;
-            [[(_pos select 0) + 7, (_pos select 1) + 7, 0], _statics, 45] call btc_fnc_mil_create_static;
+            [[(_pos select 0) + 7, (_pos select 1) + 7, 0], _statics, 45, [], _city] call btc_fnc_mil_create_static;
         };
         case (_random > 0.75) : {
             private _statics = btc_type_gl + btc_type_mg;
-            [[(_pos select 0) + 7, (_pos select 1) + 7, 0], _statics, 45] call btc_fnc_mil_create_static;
-            [[(_pos select 0) - 7, (_pos select 1) - 7, 0], _statics, 225] call btc_fnc_mil_create_static;
+            [[(_pos select 0) + 7, (_pos select 1) + 7, 0], _statics, 45, [], _city] call btc_fnc_mil_create_static;
+            [[(_pos select 0) - 7, (_pos select 1) - 7, 0], _statics, 225, [], _city] call btc_fnc_mil_create_static;
         };
     };
     if (btc_p_veh_armed_ho) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/de_activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/de_activate.sqf
@@ -58,7 +58,8 @@ if !(_city getVariable ["active", false]) exitWith {};
         if (
             (leader _x) inArea [_pos_city, _radius, _radius, 0, false] &&
             {side _x != btc_player_side} &&
-            {!(_x getVariable ["no_cache", false])}
+            {!(_x getVariable ["no_cache", false])} &&
+            {_x getVariable ["btc_city", _city] in [_city, objNull]}
         ) then {
             private _data_group = _x call btc_fnc_data_get_group;
             _data_units pushBack _data_group;
@@ -73,7 +74,8 @@ if !(_city getVariable ["active", false]) exitWith {};
         if (
             _agent inArea [_pos_city, _radius, _radius, 0, false] &&
             {alive _agent} &&
-            {!(_x getVariable ["no_cache", false])}
+            {!(_x getVariable ["no_cache", false])} &&
+            {_x getVariable ["btc_city", _city] in [_city, objNull]}
         ) then {
             _data_animals pushBack [
                 typeOf _agent,

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/add_grenade.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/add_grenade.sqf
@@ -31,7 +31,11 @@ _unit addEventHandler ["Fired", {
 
     if (_weapon isEqualTo "Throw") then {
         _unit removeEventHandler ["Fired", _thisEventHandler];
-        [_unit] joinSilent createGroup [civilian, true];
+
+        private _group = createGroup [civilian, true];
+        _group setVariable ["btc_city", group _unit getVariable ["btc_city", objNull]];
+        [_unit] joinSilent _group;
+
         [{
             params ["_unit"];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/get_grenade.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/get_grenade.sqf
@@ -46,9 +46,10 @@ if (_units isEqualTo []) exitWith {};
 
     [_x] call btc_fnc_civ_add_grenade;
 
-    [_x] joinSilent createGroup [btc_enemy_side, true];
+    private _group = createGroup [btc_enemy_side, true];
+    _group setVariable ["btc_city", group _x getVariable ["btc_city", objNull]];
+    [_x] joinSilent _group;
 
-    private _group = group _x;
     [_group] call CBA_fnc_clearWaypoints;
     _group setVariable ["getWeapons", true];
     [_group, _pos, -1, "GUARD", "AWARE", "RED", nil, nil, nil, nil, 10] call CBA_fnc_addWaypoint;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/get_weapons.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/get_weapons.sqf
@@ -44,8 +44,10 @@ if (_units isEqualTo []) then {
     [_x, "", 2] call ace_common_fnc_doAnimation;
     [_x] call btc_fnc_civ_add_weapons;
 
-    [_x] joinSilent createGroup [btc_enemy_side, true];
-    private _group = group _x;
+    private _group = createGroup [btc_enemy_side, true];
+    _group setVariable ["btc_city", group _x getVariable ["btc_city", objNull]];
+    [_x] joinSilent _group;
+    
     [_group] call CBA_fnc_clearWaypoints;
     _group setVariable ["getWeapons", true];
     [_group, getPos _x, -1, "GUARD", "AWARE", "RED", nil, nil, nil, nil, 10] call CBA_fnc_addWaypoint;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/populate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/populate.sqf
@@ -8,6 +8,7 @@ Description:
 Parameters:
     _houses - Houses to populate around a city. [Number]
     _n - Number of civilians to generate. [Number]
+    _city - City where the civilian is created. [Object]
 
 Returns:
 
@@ -23,7 +24,8 @@ Author:
 
 params [
     ["_houses", [], [[]]],
-    ["_n", 0, [0]]
+    ["_n", 0, [0]],
+    ["_city", objNull, [objNull]]
 ];
 
 if (_houses isEqualTo []) exitWith {};
@@ -34,6 +36,7 @@ for "_i" from 1 to _n do {
     private _pos = (_houses deleteAt 0) buildingPos 0;
 
     private _group = createGroup civilian;
+    _group setVariable ["btc_city", _city];
     _group setVariable ["btc_data_inhouse", [_pos]];
     [_group, _pos] call btc_fnc_civ_addWP;
     [_group, selectRandom btc_civ_type_units, _pos] call btc_fnc_delay_createUnit;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/data/add_group.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/data/add_group.sqf
@@ -52,7 +52,9 @@ private _wp = if (vehicle leader _group isEqualTo leader _group) then {
 
 [_group, _city, 200, _wp] call btc_fnc_mil_addWP;
 
-if !(_city getVariable ["active", false]) then {
+if (_city getVariable ["active", false]) then {
+    _group setVariable ["btc_city", _city];
+} else {
     private _data_units = _city getVariable ["data_units", []];
     private _data_group = _group call btc_fnc_data_get_group;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/data/spawn_group.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/data/spawn_group.sqf
@@ -15,7 +15,7 @@ Parameters:
         _behaviour - Behaviour of units. [Array]
         _array_wp - Waypoints of group. [Array]
         _array_veh - Vehicle occupied by the group. [Array, String]
-    _cityID - City ID. [Number]
+    _city - City. [Object]
 
 Returns:
     _delay - Delay due to vehicle spawn. [Number]
@@ -32,7 +32,7 @@ Author:
 
 params [
     ["_data_unit", [], [[]]],
-    ["_cityID", 0, [0]]
+    ["_city", objNull, [objNull]]
 ];
 _data_unit params [
     ["_type", 1, [0]],
@@ -47,15 +47,16 @@ _data_unit params [
 
 private _delay = 0;
 if (_type isEqualTo 5) exitWith {
-    [objNull, 100, _array_pos select 0, _array_type select 0] call btc_fnc_ied_suicider_create;
+    [_city, 100, _array_pos select 0, _array_type select 0] call btc_fnc_ied_suicider_create;
     _delay
 };
 if (_type isEqualTo 7) exitWith {
-    [objNull, 100, _array_pos select 0] call btc_fnc_ied_drone_create;
+    [_city, 100, _array_pos select 0] call btc_fnc_ied_drone_create;
     _delay
 };
 
 private _group = createGroup _side;
+_group setVariable ["btc_city", _city];
 if (_type isEqualTo 1) then {
     _array_veh params ["_typeOf", "_posATL", "_dir", "_fuel", ["_vectorUp", []]];
     _delay = [_group, _typeOf, _array_type, _posATL, _dir, _fuel, _vectorUp] call btc_fnc_delay_createVehicle;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/delay/createAgent.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/delay/createAgent.sqf
@@ -9,6 +9,7 @@ Parameters:
     _agentType - Type of agents to create. [Array]
     _pos - Position of creation. [Array]
     _special - Agent placement special. [String]
+    _city - City where the animal is created. [Object]
 
 Returns:
 
@@ -28,10 +29,11 @@ btc_delay_createUnit = btc_delay_createUnit + 0.1;
     params [
         ["_agentType", "", [""]],
         ["_pos", [0, 0, 0], [[]]],
-        ["_special", "CAN_COLLIDE", [""]]
+        ["_special", "CAN_COLLIDE", [""]],
+        ["_city", objNull, [objNull]]
     ];
 
-    createAgent [_agentType, _pos, [], 0, _special];
+    (createAgent [_agentType, _pos, [], 0, _special]) setVariable ["btc_city", _city];
 
     btc_delay_createUnit = btc_delay_createUnit - 0.1;
 }, _this, btc_delay_createUnit - 0.01] call CBA_fnc_waitAndExecute;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/drone_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/drone_create.sqf
@@ -38,6 +38,7 @@ if (_rpos isEqualTo []) then {
 };
 
 private _group = createGroup [btc_enemy_side, true];
+_group setVariable ["btc_city", _city];
 private _drone = createVehicle ["C_IDAP_UAV_06_antimine_F", _rpos, [], 0, "FLY"];
 createVehicleCrew _drone;
 [driver _drone] joinSilent _group;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_create.sqf
@@ -43,6 +43,7 @@ if (_type_units isEqualTo "") then {
 };
 
 private _group = createGroup [civilian, true];
+_group setVariable ["btc_city", _city];
 private _suicider = _group createUnit [_type_units, _rpos, [], 0, "CAN_COLLIDE"];
 
 [_group] call btc_fnc_civ_addWP;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_group.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_group.sqf
@@ -45,6 +45,9 @@ _wp_ratios params ["_wp_house_probability", "_wp_sentry_probability"];
 ([_city, _area] call btc_fnc_city_findPos) params ["_rpos", "_pos_iswater"];
 
 private _group = createGroup _enemy_side;
+if (_city isEqualType objNull) then {
+    _group setVariable ["btc_city", _city];
+};
 private _groups = [];
 _groups pushBack _group;
 
@@ -57,6 +60,9 @@ switch (true) do {
         };
         for "_i" from 1 to _n do {
             private _grp = createGroup _enemy_side;
+            if (_city isEqualType objNull) then {
+                _grp setVariable ["btc_city", _city];
+            };
             [_grp, _rpos, 1] call btc_fnc_mil_createUnits;
             _grp setVariable ["btc_inHouse", typeOf _structure];
             [_grp, _structure] call btc_fnc_house_addWP;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_static.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_static.sqf
@@ -10,6 +10,7 @@ Parameters:
     _statics_type - Type of static available. [Array]
     _dir - Direction of the static. [Number]
     _surfaceNormal - Surface normal. [Array]
+    _city - City where the static is created. [Object]
 
 Returns:
     _static - Created static. [Object]
@@ -28,10 +29,12 @@ params [
     ["_pos", [0, 0, 0], [[]]],
     ["_statics_type", btc_type_mg, [[]]],
     ["_dir", 0, [0]],
-    ["_surfaceNormal", [], [[]]]
+    ["_surfaceNormal", [], [[]]],
+    ["_city", objNull, [objNull]]
 ];
 
 private _group = createGroup btc_enemy_side;
+_group setVariable ["btc_city", _city];
 [_group] call CBA_fnc_clearWaypoints;
 [_group, _pos, selectRandom _statics_type, _dir, _surfaceNormal] call btc_fnc_mil_createVehicle;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_staticOnRoof.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_staticOnRoof.sqf
@@ -8,6 +8,7 @@ Description:
 Parameters:
     _house - House to find the roof. [Group]
     _n - Number of static to generate. [Number]
+    _city - City where the static is created. [Object]
 
 Returns:
 
@@ -23,7 +24,8 @@ Author:
 
 params [
     ["_houses", [], [[]]],
-    ["_n", 0, [0]]
+    ["_n", 0, [0]],
+    ["_city", objNull, [objNull]]
 ];
 
 private _j = 1;
@@ -34,7 +36,7 @@ for "_i" from 1 to _n do {
     ([_house] call btc_fnc_roof) params ["_spawnPos", "_surfaceNormal"];
 
     if (acos (_surfaceNormal vectorCos [0, 0, 1]) < 30) then {
-        [ASLToATL _spawnPos, btc_type_mg + btc_type_gl, (_house getDir _spawnPos) + (random [-15, 0, 15]), _surfaceNormal] call btc_fnc_mil_create_static;
+        [ASLToATL _spawnPos, btc_type_mg + btc_type_gl, (_house getDir _spawnPos) + (random [-15, 0, 15]), _surfaceNormal, _city] call btc_fnc_mil_create_static;
         _j = _i;
     } else {
         _i = _j;


### PR DESCRIPTION
- Ignorechangelog

**When merged this pull request will:**
- title
- Each AI is attributed to a city so even when city overlap, each AI is saved to the correct city

**Final test:**
- [x] local
- [x] server