### PR TITLE
Add: Enemy will surrender when city becomes free

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -84,7 +84,12 @@ btc_p_trigger = if (("btc_p_trigger" call BIS_fnc_getParamValue) isEqualTo 1) th
 } else {
     "this"
 };
-btc_p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamValue;
+private _p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamValue;
+btc_p_city_free_trigger_condition = if (_p_city_free_trigger isEqualTo 0) then {
+    "thisList isEqualTo []"
+} else {
+    format ["[thisList, %1] call btc_fnc_city_trigger_free_condition", _p_city_free_trigger]
+};
 btc_p_auto_headless = ("btc_p_auto_headless" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_debug = "btc_p_debug" call BIS_fnc_getParamValue;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -86,7 +86,7 @@ btc_p_trigger = if (("btc_p_trigger" call BIS_fnc_getParamValue) isEqualTo 1) th
 };
 private _p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamValue;
 btc_p_city_free_trigger_condition = if (_p_city_free_trigger isEqualTo 0) then {
-    "count thisList <= 0"
+    thisList isEqualTo = []"
 } else {
     format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits append (crew vehicle _x);} forEach thisList; _remainEnemyUnits arrayIntersect _remainEnemyUnits; count _remainEnemyUnits <= %2", _p_city_free_trigger, _p_city_free_trigger]
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -84,7 +84,11 @@ btc_p_trigger = if (("btc_p_trigger" call BIS_fnc_getParamValue) isEqualTo 1) th
 } else {
     "this"
 };
-btc_p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamValue;
+btc_p_city_free_trigger = if (("btc_p_city_free_trigger" call BIS_fnc_getParamValue) isEqualTo 0) then {
+    "count thisList <= 0"
+} else {
+    format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits pushBackUnique (crew vehicle _x);} forEach thisList; count _remainEnemyUnits <= %1", btc_p_city_free_trigger]
+};
 btc_p_auto_headless = ("btc_p_auto_headless" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_debug = "btc_p_debug" call BIS_fnc_getParamValue;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -88,7 +88,7 @@ private _p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamVa
 btc_p_city_free_trigger_condition = if (_p_city_free_trigger isEqualTo 0) then {
     "thisList isEqualTo []"
 } else {
-    format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits append (crew vehicle _x);} forEach thisList; count (_remainEnemyUnits arrayIntersect _remainEnemyUnits) <= %2", _p_city_free_trigger, _p_city_free_trigger]
+    format ["if (count thisList > %1) exitWith {false}; private _return = true; private _veh; {_veh = vehicle _x; if !(_veh isKindOf 'Man' || {_veh isKindOf 'StaticWeapon' || {unitIsUAV _veh}}) exitWith {_return = false;};} forEach thisList; _return", _p_city_free_trigger, _p_city_free_trigger]
 };
 btc_p_auto_headless = ("btc_p_auto_headless" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_debug = "btc_p_debug" call BIS_fnc_getParamValue;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -88,7 +88,7 @@ private _p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamVa
 btc_p_city_free_trigger_condition = if (_p_city_free_trigger isEqualTo 0) then {
     "thisList isEqualTo []"
 } else {
-    format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits append (crew vehicle _x);} forEach thisList; count(_remainEnemyUnits arrayIntersect _remainEnemyUnits) <= %2", _p_city_free_trigger, _p_city_free_trigger]
+    format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits append (crew vehicle _x);} forEach thisList; count (_remainEnemyUnits arrayIntersect _remainEnemyUnits) <= %2", _p_city_free_trigger, _p_city_free_trigger]
 };
 btc_p_auto_headless = ("btc_p_auto_headless" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_debug = "btc_p_debug" call BIS_fnc_getParamValue;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -86,7 +86,7 @@ btc_p_trigger = if (("btc_p_trigger" call BIS_fnc_getParamValue) isEqualTo 1) th
 };
 private _p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamValue;
 btc_p_city_free_trigger_condition = if (_p_city_free_trigger isEqualTo 0) then {
-    thisList isEqualTo = []"
+    "thisList isEqualTo = []"
 } else {
     format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits append (crew vehicle _x);} forEach thisList; count(_remainEnemyUnits arrayIntersect _remainEnemyUnits) <= %2", _p_city_free_trigger, _p_city_free_trigger]
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -88,7 +88,7 @@ private _p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamVa
 btc_p_city_free_trigger_condition = if (_p_city_free_trigger isEqualTo 0) then {
     "thisList isEqualTo []"
 } else {
-    format ["if (count thisList > %1) exitWith {false}; private _return = true; private _veh; {_veh = vehicle _x; if !(_veh isKindOf 'Man' || {_veh isKindOf 'StaticWeapon' || {unitIsUAV _veh}}) exitWith {_return = false;};} forEach thisList; _return", _p_city_free_trigger, _p_city_free_trigger]
+    format ["if (count thisList > %1) exitWith {false}; private _return = true; private _veh; {_veh = vehicle _x; if !(_veh isKindOf 'Man' || {unitIsUAV _veh}) exitWith {_return = false;};} forEach thisList; _return", _p_city_free_trigger, _p_city_free_trigger]
 };
 btc_p_auto_headless = ("btc_p_auto_headless" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_debug = "btc_p_debug" call BIS_fnc_getParamValue;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -86,7 +86,7 @@ btc_p_trigger = if (("btc_p_trigger" call BIS_fnc_getParamValue) isEqualTo 1) th
 };
 private _p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamValue;
 btc_p_city_free_trigger_condition = if (_p_city_free_trigger isEqualTo 0) then {
-    "thisList isEqualTo = []"
+    "thisList isEqualTo []"
 } else {
     format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits append (crew vehicle _x);} forEach thisList; count(_remainEnemyUnits arrayIntersect _remainEnemyUnits) <= %2", _p_city_free_trigger, _p_city_free_trigger]
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -84,10 +84,11 @@ btc_p_trigger = if (("btc_p_trigger" call BIS_fnc_getParamValue) isEqualTo 1) th
 } else {
     "this"
 };
-btc_p_city_free_trigger = if (("btc_p_city_free_trigger" call BIS_fnc_getParamValue) isEqualTo 0) then {
+private _p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamValue;
+btc_p_city_free_trigger_condition = if (_p_city_free_trigger isEqualTo 0) then {
     "count thisList <= 0"
 } else {
-    format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits pushBackUnique (crew vehicle _x);} forEach thisList; count _remainEnemyUnits <= %1", btc_p_city_free_trigger]
+    format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits append (crew vehicle _x);} forEach thisList; _remainEnemyUnits arrayIntersect _remainEnemyUnits; count _remainEnemyUnits <= %2", _p_city_free_trigger, _p_city_free_trigger]
 };
 btc_p_auto_headless = ("btc_p_auto_headless" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_debug = "btc_p_debug" call BIS_fnc_getParamValue;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -84,12 +84,7 @@ btc_p_trigger = if (("btc_p_trigger" call BIS_fnc_getParamValue) isEqualTo 1) th
 } else {
     "this"
 };
-private _p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamValue;
-btc_p_city_free_trigger_condition = if (_p_city_free_trigger isEqualTo 0) then {
-    "thisList isEqualTo []"
-} else {
-    format ["if (count thisList > %1) exitWith {false}; private _return = true; private _veh; {_veh = vehicle _x; if !(_veh isKindOf 'Man' || {unitIsUAV _veh}) exitWith {_return = false;};} forEach thisList; _return", _p_city_free_trigger, _p_city_free_trigger]
-};
+btc_p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamValue;
 btc_p_auto_headless = ("btc_p_auto_headless" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_debug = "btc_p_debug" call BIS_fnc_getParamValue;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -88,7 +88,7 @@ private _p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamVa
 btc_p_city_free_trigger_condition = if (_p_city_free_trigger isEqualTo 0) then {
     thisList isEqualTo = []"
 } else {
-    format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits append (crew vehicle _x);} forEach thisList; _remainEnemyUnits arrayIntersect _remainEnemyUnits; count _remainEnemyUnits <= %2", _p_city_free_trigger, _p_city_free_trigger]
+    format ["if (count thisList > %1) exitWith {false}; private _remainEnemyUnits = []; {_remainEnemyUnits append (crew vehicle _x);} forEach thisList; count(_remainEnemyUnits arrayIntersect _remainEnemyUnits) <= %2", _p_city_free_trigger, _p_city_free_trigger]
 };
 btc_p_auto_headless = ("btc_p_auto_headless" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_debug = "btc_p_debug" call BIS_fnc_getParamValue;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -84,6 +84,7 @@ btc_p_trigger = if (("btc_p_trigger" call BIS_fnc_getParamValue) isEqualTo 1) th
 } else {
     "this"
 };
+btc_p_city_free_trigger = "btc_p_city_free_trigger" call BIS_fnc_getParamValue;
 btc_p_auto_headless = ("btc_p_auto_headless" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_debug = "btc_p_debug" call BIS_fnc_getParamValue;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -395,6 +395,12 @@ class Params {
         texts[]={$STR_DISABLED,$STR_ENABLED};
         default = 0;
     };
+    class btc_p_city_free_trigger { // City will be free if number of enemies is equal or lower than:
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_OTHER_CITYFREE"]);
+        values[]={0,1,2,3,4,5};
+        texts[]={$STR_DISABLED,"1","2","3","4","5"};
+        default = 0;
+    };
     class btc_p_auto_headless { // Autodetect Headless client:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_OTHER_AUTOHEADLESS"]);
         values[]={0,1};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -397,8 +397,8 @@ class Params {
     };
     class btc_p_city_free_trigger { // City will be free if number of enemies is equal or lower than:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_OTHER_CITYFREE"]);
-        values[]={0,1,2,3,4,5};
-        texts[]={$STR_DISABLED,"1","2","3","4","5"};
+        values[]={0,1,2,3};
+        texts[]={$STR_DISABLED,"1","2","3"};
         default = 0;
     };
     class btc_p_auto_headless { // Autodetect Headless client:

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -269,7 +269,7 @@ if (_city getVariable ["data_tags", []] isEqualTo []) then {
         private _trigger = createTrigger ["EmptyDetector", getPos _city];
         _trigger setTriggerArea [_radius, _radius, 0, false];
         _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
-        _trigger setTriggerStatements [btc_p_city_free_trigger_condition, format ["[%1, thisList] call btc_fnc_city_set_clear", _id], ""];
+        _trigger setTriggerStatements ["[thisList] call btc_fnc_city_trigger_free_condition", format ["[%1, thisList] call btc_fnc_city_set_clear", _id], ""];
         _trigger setTriggerInterval 2;
         _city setVariable ["trigger", _trigger];
     };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -269,7 +269,7 @@ if (_city getVariable ["data_tags", []] isEqualTo []) then {
         private _trigger = createTrigger ["EmptyDetector", getPos _city];
         _trigger setTriggerArea [_radius, _radius, 0, false];
         _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
-        _trigger setTriggerStatements ["(count thisList) <= btc_p_city_free_trigger", format ["[%1, _thisList] call btc_fnc_city_set_clear", _id], ""];
+        _trigger setTriggerStatements ["(count thisList) <= btc_p_city_free_trigger", format ["[%1, thisList] call btc_fnc_city_set_clear", _id], ""];
         _trigger setTriggerInterval 2;
         _city setVariable ["trigger", _trigger];
     };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -14,6 +14,7 @@ Parameters:
     _p_civ_max_veh - Maximum number of civilian patrol. [Number]
     _p_patrol_max - Maximum number of enemy patrol. [Number]
     _wp_ratios - Ratio of spawned group in and out houses. [Array]
+    _p_city_free_trigger - City will be free if number of enemy is equal or lower than this value. [Number]
 
 Returns:
 
@@ -35,7 +36,8 @@ params [
     ["_p_animals_group_ratio", btc_p_animals_group_ratio, [0]],
     ["_p_civ_max_veh", btc_p_civ_max_veh, [0]],
     ["_p_patrol_max", btc_p_patrol_max, [0]],
-    ["_wp_ratios", btc_p_mil_wp_ratios, [[]]]
+    ["_wp_ratios", btc_p_mil_wp_ratios, [[]]],
+    ["_p_city_free_trigger", btc_p_city_free_trigger, [0]]
 ];
 _wp_ratios params ["_wp_house", "_wp_sentry"];
 
@@ -270,7 +272,7 @@ if (_city getVariable ["data_tags", []] isEqualTo []) then {
         _trigger setTriggerArea [_radius, _radius, 0, false];
         _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
         _trigger setTriggerInterval 15;
-        _trigger setTriggerStatements ["(count thisList) < (3 + random 3)", format ["[%1] call btc_fnc_city_set_clear", _id], ""];
+        _trigger setTriggerStatements [format ["(count thisList) <= %1", _p_city_free_trigger], format ["[%1, _thisList] call btc_fnc_city_set_clear", _id], ""];
         _city setVariable ["trigger", _trigger];
     };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -269,8 +269,8 @@ if (_city getVariable ["data_tags", []] isEqualTo []) then {
         private _trigger = createTrigger ["EmptyDetector", getPos _city];
         _trigger setTriggerArea [_radius, _radius, 0, false];
         _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
-        _trigger setTriggerInterval 2;
         _trigger setTriggerStatements ["(count thisList) <= btc_p_city_free_trigger", format ["[%1, _thisList] call btc_fnc_city_set_clear", _id], ""];
+        _trigger setTriggerInterval 2;
         _city setVariable ["trigger", _trigger];
     };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -272,7 +272,7 @@ if (_city getVariable ["data_tags", []] isEqualTo []) then {
         _trigger setTriggerArea [_radius, _radius, 0, false];
         _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
         _trigger setTriggerInterval 2;
-        _trigger setTriggerStatements [format ["(count thisList) <= %1", _p_city_free_trigger], format ["[%1, _thisList] call btc_fnc_city_set_clear", _id], ""];
+        _trigger setTriggerStatements ["(count thisList) <= btc_p_city_free_trigger", format ["[%1, _thisList] call btc_fnc_city_set_clear", _id], ""];
         _city setVariable ["trigger", _trigger];
     };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -269,7 +269,7 @@ if (_city getVariable ["data_tags", []] isEqualTo []) then {
         private _trigger = createTrigger ["EmptyDetector", getPos _city];
         _trigger setTriggerArea [_radius, _radius, 0, false];
         _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
-        _trigger setTriggerStatements [btc_p_city_free_trigger, format ["[%1, thisList] call btc_fnc_city_set_clear", _id], ""];
+        _trigger setTriggerStatements [btc_p_city_free_trigger_condition, format ["[%1, thisList] call btc_fnc_city_set_clear", _id], ""];
         _trigger setTriggerInterval 2;
         _city setVariable ["trigger", _trigger];
     };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -271,7 +271,7 @@ if (_city getVariable ["data_tags", []] isEqualTo []) then {
         private _trigger = createTrigger ["EmptyDetector", getPos _city];
         _trigger setTriggerArea [_radius, _radius, 0, false];
         _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
-        _trigger setTriggerInterval 15;
+        _trigger setTriggerInterval 2;
         _trigger setTriggerStatements [format ["(count thisList) <= %1", _p_city_free_trigger], format ["[%1, _thisList] call btc_fnc_city_set_clear", _id], ""];
         _city setVariable ["trigger", _trigger];
     };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -269,7 +269,7 @@ if (_city getVariable ["data_tags", []] isEqualTo []) then {
         private _trigger = createTrigger ["EmptyDetector", getPos _city];
         _trigger setTriggerArea [_radius, _radius, 0, false];
         _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
-        _trigger setTriggerStatements ["(count thisList) <= btc_p_city_free_trigger", format ["[%1, thisList] call btc_fnc_city_set_clear", _id], ""];
+        _trigger setTriggerStatements [btc_p_city_free_trigger, format ["[%1, thisList] call btc_fnc_city_set_clear", _id], ""];
         _trigger setTriggerInterval 2;
         _city setVariable ["trigger", _trigger];
     };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -269,7 +269,7 @@ if (_city getVariable ["data_tags", []] isEqualTo []) then {
         private _trigger = createTrigger ["EmptyDetector", getPos _city];
         _trigger setTriggerArea [_radius, _radius, 0, false];
         _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
-        _trigger setTriggerStatements ["[thisList] call btc_fnc_city_trigger_free_condition", format ["[%1, thisList] call btc_fnc_city_set_clear", _id], ""];
+        _trigger setTriggerStatements [btc_p_city_free_trigger_condition, format ["[%1, thisList] call btc_fnc_city_set_clear", _id], ""];
         _trigger setTriggerInterval 2;
         _city setVariable ["trigger", _trigger];
     };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -268,8 +268,9 @@ if (_city getVariable ["data_tags", []] isEqualTo []) then {
     if (_has_en) then {
         private _trigger = createTrigger ["EmptyDetector", getPos _city];
         _trigger setTriggerArea [_radius, _radius, 0, false];
-        _trigger setTriggerActivation [str btc_enemy_side, "NOT PRESENT", false];
-        _trigger setTriggerStatements ["this", format ["[%1] call btc_fnc_city_set_clear", _id], ""];
+        _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
+        _trigger setTriggerInterval 15;
+        _trigger setTriggerStatements ["(count thisList) < (3 + random 3)", format ["[%1] call btc_fnc_city_set_clear", _id], ""];
         _city setVariable ["trigger", _trigger];
     };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -14,7 +14,6 @@ Parameters:
     _p_civ_max_veh - Maximum number of civilian patrol. [Number]
     _p_patrol_max - Maximum number of enemy patrol. [Number]
     _wp_ratios - Ratio of spawned group in and out houses. [Array]
-    _p_city_free_trigger - City will be free if number of enemy is equal or lower than this value. [Number]
 
 Returns:
 
@@ -36,8 +35,7 @@ params [
     ["_p_animals_group_ratio", btc_p_animals_group_ratio, [0]],
     ["_p_civ_max_veh", btc_p_civ_max_veh, [0]],
     ["_p_patrol_max", btc_p_patrol_max, [0]],
-    ["_wp_ratios", btc_p_mil_wp_ratios, [[]]],
-    ["_p_city_free_trigger", btc_p_city_free_trigger, [0]]
+    ["_wp_ratios", btc_p_mil_wp_ratios, [[]]]
 ];
 _wp_ratios params ["_wp_house", "_wp_sentry"];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
@@ -31,27 +31,17 @@ _city setVariable ["occupied", false];
 
 if !(_remainEnemyUnits isEqualTo []) then {
     {
+        private _enemyUnitsToSurrender = _remainEnemyUnits;
         private _vehicle = vehicle _x;
         if (unitIsUAV _vehicle) then {
             _x setDamage 1;
         } else {
-            if (_vehicle isKindOf "Air" || {_vehicle isKindOf "Ship"}) then {
-                _remainEnemyUnits = _remainEnemyUnits - crew _vehicle;
-            } else {
-                if (_vehicle isKindOf "LandVehicle") then {
-                    private _crew = crew _vehicle;
-                    _crew allowGetIn false;
-                    {
-                        moveOut _x;
-                        [_x, true] call ace_captives_fnc_setSurrendered;
-                    } forEach _crew;
-                    _remainEnemyUnits = _remainEnemyUnits - _crew;
-                } else {
-                    [_x, true] call ace_captives_fnc_setSurrendered;
-                };
+            if (_vehicle isKindOf "LandVehicle" || {_vehicle isKindOf "Air" || {_vehicle isKindOf "Ship"}}) then {
+                _enemyUnitsToSurrender = _enemyUnitsToSurrender - crew _vehicle;
             };
         };
     } forEach _remainEnemyUnits;
+    {[_x, true] call ace_captives_fnc_setSurrendered;} forEach _enemyUnitsToSurrender;
 };
 
 if (_city getVariable ["marker", ""] != "") then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
@@ -31,17 +31,22 @@ _city setVariable ["occupied", false];
 
 if !(_remainEnemyUnits isEqualTo []) then {
     {
-        private _enemyUnitsToSurrender = _remainEnemyUnits;
         private _vehicle = vehicle _x;
         if (unitIsUAV _vehicle) then {
             _x setDamage 1;
         } else {
-            if (_vehicle isKindOf "LandVehicle" || {_vehicle isKindOf "Air" || {_vehicle isKindOf "Ship"}}) then {
-                _enemyUnitsToSurrender = _enemyUnitsToSurrender - crew _vehicle;
+            if (_vehicle isKindOf "StaticWeapon") then {
+                private _crew = crew _vehicle;
+                _crew allowGetIn false;
+                {
+                    moveOut _x;
+                    [_x, true] call ace_captives_fnc_setSurrendered;
+                } forEach _crew;
+            } else {
+                [_x, true] call ace_captives_fnc_setSurrendered;
             };
         };
     } forEach _remainEnemyUnits;
-    {[_x, true] call ace_captives_fnc_setSurrendered;} forEach _enemyUnitsToSurrender;
 };
 
 if (_city getVariable ["marker", ""] != "") then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
@@ -38,7 +38,7 @@ if !(_remainEnemyUnits isEqualTo []) then {
             if !(_vehicle isEqualTo _x) then {
                 doGetOut _x;
             };
-            [_x, true] call ace_captives_setSurrendered;
+            [_x, true] call ace_captives_fnc_setSurrendered;
         };
     } forEach _remainEnemyUnits;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
@@ -7,6 +7,7 @@ Description:
 
 Parameters:
     _id - ID of the city no more occupied. [Number]
+    _remainEnemyUnits - Remaining enemy units assigned to the city. [Array]
 
 Returns:
 
@@ -21,11 +22,26 @@ Author:
 ---------------------------------------------------------------------------- */
 
 params [
-    ["_id", 0, [0]]
+    ["_id", 0, [0]],
+    ["_remainEnemyUnits", [], [[]]]
 ];
 
 private _city = btc_city_all select _id;
 _city setVariable ["occupied", false];
+
+if !(_remainEnemyUnits isEqualTo []) then {
+    {
+        private _vehicle = vehicle _x;
+        if (getNumber (_cfgVehicles >> _vehicle >> "isUav") isEqualTo 1) then {
+            _x setDamage 1;
+        } else {
+            if !(_vehicle isEqualTo _x) then {
+                doGetOut _x;
+            };
+            [_x, true] call ace_captives_setSurrendered;
+        };
+    } forEach _remainEnemyUnits;
+};
 
 if (_city getVariable ["marker", ""] != "") then {
     (_city getVariable ["marker", ""]) setMarkerColor "ColorGreen";
@@ -38,15 +54,3 @@ if (btc_final_phase) then {
 if (btc_debug) then {
     (format ["loc_%1", _id]) setMarkerColor "ColorGreen";
 };
-
-{
-    private _vehicle = vehicle _x;
-    if (getNumber (_cfgVehicles >> _vehicle >> "isUav") isEqualTo 1) then {
-        _x setDamage 1;
-    } else {
-        if !(_vehicle isEqualTo _x) then {
-            doGetOut _x;
-        };
-        [_x, true] call ace_captives_setSurrendered;
-    };
-} forEach (_city getVariable ["data_units", []]);

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
@@ -33,13 +33,24 @@ if !(_remainEnemyUnits isEqualTo []) then {
     private _cfgVehicles = configFile >> "CfgVehicles";
     {
         private _vehicle = vehicle _x;
-        if (getNumber (_cfgVehicles >> typeOf _vehicle >> "isUav") isEqualTo 1) then {
+        if (getNumber (configOf _vehicle >> "isUav") isEqualTo 1) then {
             _x setDamage 1;
         } else {
-            if !(_vehicle isEqualTo _x) then {
-                doStop _x;
+            if (_vehicle isKindOf "Air" || {_vehicle isKindOf "Ship"}) then {
+                _remainEnemyUnits = _remainEnemyUnits - crew _vehicle;
+            } else {
+                if (_vehicle isKindOf "LandVehicle") then {
+                    private _crew = crew _vehicle;
+                    _crew allowGetIn false;
+                    {
+                        moveOut _x;
+                        [_x, true] call ace_captives_fnc_setSurrendered;
+                    } forEach _crew;
+                    _remainEnemyUnits = _remainEnemyUnits - _crew;
+                } else {
+                    [_x, true] call ace_captives_fnc_setSurrendered;
+                };
             };
-            [_x, true] call ace_captives_fnc_setSurrendered;
         };
     } forEach _remainEnemyUnits;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
@@ -31,20 +31,10 @@ _city setVariable ["occupied", false];
 
 if !(_remainEnemyUnits isEqualTo []) then {
     {
-        private _vehicle = vehicle _x;
-        if (unitIsUAV _vehicle) then {
+        if (unitIsUAV _x) then {
             _x setDamage 1;
         } else {
-            if (_vehicle isKindOf "StaticWeapon") then {
-                private _crew = crew _vehicle;
-                _crew allowGetIn false;
-                {
-                    moveOut _x;
-                    [_x, true] call ace_captives_fnc_setSurrendered;
-                } forEach _crew;
-            } else {
-                [_x, true] call ace_captives_fnc_setSurrendered;
-            };
+            [_x, true] call ace_captives_fnc_setSurrendered;
         };
     } forEach _remainEnemyUnits;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
@@ -32,7 +32,7 @@ _city setVariable ["occupied", false];
 if !(_remainEnemyUnits isEqualTo []) then {
     {
         private _vehicle = vehicle _x;
-        if (getNumber (configOf _vehicle >> "isUav") isEqualTo 1) then {
+        if (unitIsUAV _vehicle) then {
             _x setDamage 1;
         } else {
             if (_vehicle isKindOf "Air" || {_vehicle isKindOf "Ship"}) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
@@ -38,3 +38,15 @@ if (btc_final_phase) then {
 if (btc_debug) then {
     (format ["loc_%1", _id]) setMarkerColor "ColorGreen";
 };
+
+{
+    private _vehicle = vehicle _x;
+    if (getNumber (_cfgVehicles >> _vehicle >> "isUav") isEqualTo 1) then {
+        _x setDamage 1;
+    } else {
+        if !(_vehicle isEqualTo _x) then {
+            doGetOut _x;
+        };
+        [_x, true] call ace_captives_setSurrendered;
+    };
+} forEach (_city getVariable ["data_units", []]);

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
@@ -30,7 +30,6 @@ private _city = btc_city_all select _id;
 _city setVariable ["occupied", false];
 
 if !(_remainEnemyUnits isEqualTo []) then {
-    private _cfgVehicles = configFile >> "CfgVehicles";
     {
         private _vehicle = vehicle _x;
         if (getNumber (configOf _vehicle >> "isUav") isEqualTo 1) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/set_clear.sqf
@@ -30,13 +30,14 @@ private _city = btc_city_all select _id;
 _city setVariable ["occupied", false];
 
 if !(_remainEnemyUnits isEqualTo []) then {
+    private _cfgVehicles = configFile >> "CfgVehicles";
     {
         private _vehicle = vehicle _x;
-        if (getNumber (_cfgVehicles >> _vehicle >> "isUav") isEqualTo 1) then {
+        if (getNumber (_cfgVehicles >> typeOf _vehicle >> "isUav") isEqualTo 1) then {
             _x setDamage 1;
         } else {
             if !(_vehicle isEqualTo _x) then {
-                doGetOut _x;
+                doStop _x;
             };
             [_x, true] call ace_captives_fnc_setSurrendered;
         };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_free_condition.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_free_condition.sqf
@@ -7,13 +7,14 @@ Description:
 
 Parameters:
     _remainEnemyUnits - Remaining enemy units assigned to the city, passed by the trigger. [Array]
+    _p_city_free_trigger - Minimum number of units to consider a city free. [Number]
 
 Returns:
     _return - If the city should be free. [Boolean]
 
 Examples:
     (begin example)
-        [_remainEnemyUnits] call btc_fnc_city_trigger_free_condition;
+        [allUnits inAreaArray [getPos player, 100, 100], 2] call btc_fnc_city_trigger_free_condition;
     (end)
 
 Author:
@@ -22,18 +23,15 @@ Author:
 ---------------------------------------------------------------------------- */
 
 params [
-     ["_remainEnemyUnits", [], [[]]]
+    ["_remainEnemyUnits", [], [[]]],
+    ["_p_city_free_trigger", 0, [0]]
 ];
 
-if (btc_p_city_free_trigger isEqualTo 0) then {
-    _remainEnemyUnits isEqualTo []
-} else {
-    if (count _remainEnemyUnits > btc_p_city_free_trigger) exitWith {false};
-    _remainEnemyUnits findIf {
-        private _veh = vehicle _x;
-        !(
-            _veh isKindOf "Man" ||
-            {unitIsUAV _veh}
-        )
-    } isEqualTo -1
-};
+if (count _remainEnemyUnits > _p_city_free_trigger) exitWith {false};
+_remainEnemyUnits findIf {
+    private _veh = vehicle _x;
+    !(
+        _veh isKindOf "Man" ||
+        {unitIsUAV _veh}
+    )
+} isEqualTo -1

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_free_condition.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_free_condition.sqf
@@ -1,0 +1,44 @@
+
+/* ----------------------------------------------------------------------------
+Function: btc_fnc_city_trigger_free_condition
+
+Description:
+    Check if a city should be free.
+
+Parameters:
+    _remainEnemyUnits - Remaining enemy units assigned to the city, passed by the trigger. [Array]
+
+Returns:
+    _return - If the city should be free. [Boolean]
+
+Examples:
+    (begin example)
+        [_remainEnemyUnits] call btc_fnc_city_trigger_free_condition;
+    (end)
+
+Author:
+    GoldJohnKing
+
+---------------------------------------------------------------------------- */
+
+params [
+     ["_remainEnemyUnits", [], [[]]]
+];
+
+if (btc_p_city_free_trigger isEqualTo 0) then {
+    _remainEnemyUnits isEqualTo []
+} else {
+    if (count _remainEnemyUnits > btc_p_city_free_trigger) exitWith {
+        false
+    };
+
+    private _return = true;
+    private _veh;
+    {
+        _veh = vehicle _x;
+        if !(_veh isKindOf 'Man' || {unitIsUAV _veh}) exitWith {
+            _return = false;
+        };
+    } forEach _remainEnemyUnits;
+    _return
+}

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_free_condition.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_free_condition.sqf
@@ -28,17 +28,12 @@ params [
 if (btc_p_city_free_trigger isEqualTo 0) then {
     _remainEnemyUnits isEqualTo []
 } else {
-    if (count _remainEnemyUnits > btc_p_city_free_trigger) exitWith {
-        false
-    };
-
-    private _return = true;
-    private _veh;
-    {
-        _veh = vehicle _x;
-        if !(_veh isKindOf 'Man' || {unitIsUAV _veh}) exitWith {
-            _return = false;
-        };
-    } forEach _remainEnemyUnits;
-    _return
+    if (count _remainEnemyUnits > btc_p_city_free_trigger) exitWith {false};
+    _remainEnemyUnits findIf {
+        private _veh = vehicle _x;
+        !(
+            _veh isKindOf 'Man' ||
+            {unitIsUAV _veh}
+        )
+    } isEqualTo -1
 }

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_free_condition.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_free_condition.sqf
@@ -32,8 +32,8 @@ if (btc_p_city_free_trigger isEqualTo 0) then {
     _remainEnemyUnits findIf {
         private _veh = vehicle _x;
         !(
-            _veh isKindOf 'Man' ||
+            _veh isKindOf "Man" ||
             {unitIsUAV _veh}
         )
     } isEqualTo -1
-}
+};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -41,6 +41,7 @@ if (isServer) then {
     btc_fnc_city_trigger_player_side = compile preprocessFileLineNumbers "core\fnc\city\trigger_player_side.sqf";
     btc_fnc_city_findPos = compile preprocessFileLineNumbers "core\fnc\city\findPos.sqf";
     btc_fnc_city_cleanUp = compile preprocessFileLineNumbers "core\fnc\city\cleanUp.sqf";
+    btc_fnc_city_trigger_free_condition = compile preprocessFileLineNumbers "core\fnc\city\trigger_free_condition.sqf";
 
     //CIV
     btc_fnc_civ_add_weapons = compile preprocessFileLineNumbers "core\fnc\civ\add_weapons.sqf";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -698,6 +698,10 @@
                 <Portuguese>Desativar o surgimento de unidades na cidade quando uma aeronave ou helicóptero estiver sobrevoando em velocidade (&gt;190km/h): </Portuguese>
                 <Chinesesimp>当飞机或直升机(&gt;190Km/h)飞掠城市上空时, 不激活城市:</Chinesesimp>
             </Key>
+            <Key ID="STR_BTC_HAM_PARAM_OTHER_CITYFREE">
+                <Original>City will be free if number of enemies is equal or lower than:</Original>
+                <Chinesesimp>城镇将会被解放, 当敌军数量小于或等于:</Chinesesimp>
+            </Key>
             <Key ID="STR_BTC_HAM_PARAM_OTHER_AUTOHEADLESS">
                 <Original>Autodetect Headless client:</Original>
                 <German>Headless-Client automatisch erkennen:</German>


### PR DESCRIPTION
(Use English only.)

- Add: Enemy will surrender when city becomes free (@GoldJohnKing).

**When merged this pull request will:**
- If enemy amount is less than (0, 1, 2, 3), city will becomes free and remaining enemies will surrender.
- If unit is a UAV, it will be destroyed immediately.
- If unit is inside vehicle, it will dismount then surrender.
- If unit is on foot, it will surrender.
- Also added `setTriggerInterval` to decrease trigger check interval (default 0.5s now 2s), it may slightly improve performance.
- I'm new on coding, and the code seems not that gentle than I thought, so this might need to be carefully reviewed.

**_TODO_**
- [x] Need an acceptable approach to get remaining units in the city.
- [x] Add mission parameter and let server admin choose if to enable this function.
- [x] AI inside vehicle won't surrender as expected.
- [x] Prevent enemies inside "Air" and "Ship" vehicles from surrendering, as they will likely fly by instead of landing.
- [x] ~~Handle remote units on headless clients such as enemy patrols.~~ All used syntax are argument global and effect global now.
- [x] Trigger detect enemies inside the same vehicle as one enemy unit, we don't want city to be free when there's a vehicle full of enemy units.
- [x] Use new syntax `configOf`.
- [x] It's rather an ugly approach right now, we should optimize the code if possible.
- [x] Use `unitIsUAV` syntax.
- [x] Discuss behavior handling of vehicles.

**Final test:**
- [x] local
- [x] server

**Screenshots**
