### PR TITLE
FIX: Delay of one frame the H&M initialisation

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/init.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/init.sqf
@@ -1,2 +1,2 @@
 
-[compile preprocessFileLineNumbers "core\init.sqf"] call CBA_fnc_directCall;
+[compile preprocessFileLineNumbers "core\init.sqf"] call CBA_fnc_execNextFrame;


### PR DESCRIPTION
- ignore changelog.

**When merged this pull request will:**
- title
- looks like when two missions cycling on a server (persistent = 1 and autoSelectMission = true), marker and others stuff leak between map. You get marker saved from the other map

**Final test:**
- [ ] local
- [ ] server