### PR TITLE
FIX: Leaflets dropped to civilians doesn't evacuate if chapel or church are not around

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/evacuate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/evacuate.sqf
@@ -13,7 +13,7 @@ Returns:
     _civilians - Civlians found. [Array]
 Examples:
     (begin example)
-        _civilians = [[0, 0, 0], [100, 100, 100]] call btc_fnc_civ_evacuate;
+        _civilians = [getPos player] call btc_fnc_civ_evacuate;
     (end)
 
 Author:
@@ -32,6 +32,7 @@ if (_position_evac isEqualTo []) then {
     private _safe = (nearestTerrainObjects [_position, ["CHURCH", "CHAPEL"], 400]);
     if (_safe isEqualTo []) then {
         _position_evac = [_position, 0, 500, 30, 0, 60 * (pi / 180), 0] call BIS_fnc_findSafePos;
+        _position_evac set [2, 0];
     } else {
         private _safe_building = _safe select 0;
         if ((_safe_building buildingPos -1) isEqualTo []) then {


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Leaflets dropped to civilians doesn't evacuate if chapel or church are not around (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server