### PR TITLE
FIX: Multiple ViV for vehicle using vanilla ViV system

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tow/ViV.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tow/ViV.sqf
@@ -28,7 +28,7 @@ params [
 
 if (_tower setVehicleCargo _vehicleSelected) exitWith {true};
 
-private _hideVehicle = createVehicle ["Land_WaterTank_F", [0, 0, 0], [], 0, "CAN_COLLIDE"];
+private _hideVehicle = createVehicle ["Land_Shoot_House_Tunnel_Stand_F", [0, 0, 0], [], 0, "CAN_COLLIDE"];
 _hideVehicle hideObjectGlobal true;
 
 private _model_selected = (0 boundingBoxReal _vehicleSelected) select 1;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tow/ViV.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tow/ViV.sqf
@@ -28,7 +28,7 @@ params [
 
 if (_tower setVehicleCargo _vehicleSelected) exitWith {true};
 
-private _hideVehicle = createVehicle ["Land_Shoot_House_Tunnel_Stand_F", [0, 0, 0], [], 0, "CAN_COLLIDE"];
+private _hideVehicle = createVehicle ["B_LSV_01_unarmed_F", [0, 0, 0], [], 0, "CAN_COLLIDE"];
 _hideVehicle hideObjectGlobal true;
 
 private _model_selected = (0 boundingBoxReal _vehicleSelected) select 1;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tow/ropeCreate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tow/ropeCreate.sqf
@@ -35,7 +35,7 @@ if (
 
 private _canViV_wreck = false;
 if (_alreadyLoaded) then {
-    private _fakeVehicle = "Land_Shoot_House_Tunnel_Stand_F" createVehicleLocal [0, 0, 0];
+    private _fakeVehicle = "B_LSV_01_unarmed_F" createVehicleLocal [0, 0, 0];
     _canViV_wreck = _tower canVehicleCargo _fakeVehicle isEqualTo [true, true];
     deleteVehicle _fakeVehicle;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tow/ropeCreate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tow/ropeCreate.sqf
@@ -27,15 +27,15 @@ params [
 ];
 
 if !([_tower, _vehicleSelected] call btc_fnc_tow_check) exitWith {};
-private _allReadyLoaded = (getVehicleCargo _tower) findIf {isObjectHidden _x} isEqualTo -1;
+private _alreadyLoaded = (getVehicleCargo _tower) findIf {isObjectHidden _x} isEqualTo -1;
 if (
-    _allReadyLoaded &&
+    _alreadyLoaded &&
     {_tower setVehicleCargo _vehicleSelected}
 ) exitWith {};
 
 private _canViV_wreck = false;
-if (_allReadyLoaded) then {
-    private _fakeVehicle = "Land_WaterTank_F" createVehicleLocal [0, 0, 0];
+if (_alreadyLoaded) then {
+    private _fakeVehicle = "Land_Shoot_House_Tunnel_Stand_F" createVehicleLocal [0, 0, 0];
     _canViV_wreck = _tower canVehicleCargo _fakeVehicle isEqualTo [true, true];
     deleteVehicle _fakeVehicle;
 };


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Multiple ViV for vehicle using vanilla ViV system (@Vdauphin).

**When merged this pull request will:**
- title
- Use a bigger object fitting vehicle size but still fitting RHS vehicle transport
- fix misspelling already...

**Final test:**
- [x] local
- [x] server

**Screenshots**
![20210415124642_1](https://cdn.discordapp.com/attachments/730924353369145485/832205460563689493/20210415124642_1.jpg)

![20210416124626_1](https://user-images.githubusercontent.com/14364400/115014004-13e3de00-9eb2-11eb-9193-bcfb2372abfb.jpg)
![20210416124643_1](https://user-images.githubusercontent.com/14364400/115014005-147c7480-9eb2-11eb-80fa-334f8608005a.jpg)
