### PR TITLE
FIX: For server using -autoinit, objects in container are not loaded after restart

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -127,9 +127,11 @@ btc_global_reputation = profileNamespace getVariable [format ["btc_hm_%1_rep", _
 btc_vehicles = [];
 
 private _objs = +(profileNamespace getVariable [format ["btc_hm_%1_objs", _name], []]);
-{
-    [_x] call btc_fnc_db_loadObjectStatus;
-} forEach _objs;
+[{ // Can't use ace_cargo for objects created during first frame.
+    {
+        [_x] call btc_fnc_db_loadObjectStatus;
+    } forEach _this;
+}, _objs] call CBA_fnc_execNextFrame;
 
 //VEHICLES
 private _vehs = +(profileNamespace getVariable [format ["btc_hm_%1_vehs", _name], []]);

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/loadcargo.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/loadcargo.sqf
@@ -50,4 +50,4 @@ Author:
 
     //set inventory content for weapons, magazines and items
     [_obj, _inventory] call btc_fnc_log_setCargo;
-}, _this, 0.1] call CBA_fnc_waitAndExecute;
+}, _this] call CBA_fnc_execNextFrame;


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: For server using -autoinit, objects in container are not loaded after restart (@Vdauphin).

**When merged this pull request will:**
- title
- Looks like the `CBA_fnc_execNextFrame` fail in `btc_fnc_db_loadCargo` only for server using `-autoinit`
- May be the first frame do not support  `CBA_fnc_execNextFrame` but for sure there is a different behavior between server started by player and server using -autonint to start the mission

**Final test:**
- [x] local
- [x] server

**Screenshots**
