### PR TITLE
FIX: Militia can spawn inside hideout when player is near it

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/rep/call_militia.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/rep/call_militia.sqf
@@ -32,7 +32,7 @@ private _players = if (isMultiplayer) then {playableUnits} else {switchableunits
 private _start_pos = objNull;
 private _hideouts = btc_hideouts inAreaArray [_pos, 2000, 2000];
 if !(_hideouts isEqualTo []) then {
-    _hideouts = _hideouts select {_players inAreaArray [getPosWorld _hideout, 500, 500] isEqualTo []};
+    _hideouts = _hideouts select {_players inAreaArray [getPosWorld _x, 500, 500] isEqualTo []};
     if !(_hideouts isEqualTo []) then {_start_pos = selectRandom _hideouts};
 };
 


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Militia can spawn inside hideout when player is near (@Vdauphin).

**When merged this pull request will:**
- the variable `_hideout` is not define in this scope, we want `_x`. It is noticable that Arma doesn't complain of this undefine variable.

**Final test:**
- [x] local
- [x] server

**Screenshots**
