### PR TITLE
FIX: btc_hideouts is undefine when no hideout

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -131,7 +131,7 @@ if (isServer) then {
     btc_db_serverCommandPassword = "btc_password"; //Define the same password in server.cfg like this: serverCommandPassword = "btc_password";
 
     //Hideout
-    btc_hideouts = [];
+    btc_hideouts = []; publicVariable "btc_hideouts";
     btc_hideouts_id = 0;
     btc_hideouts_radius = 800;
     btc_hideout_n = _hideout_n;


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: btc_hideouts is undefine when no hideout (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
