### PR TITLE
FIX: Cap the amount of enemy spawns for an assassination and hostage rescue mission

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
@@ -43,6 +43,7 @@ if (count _houses > 3) then {
     _house = _houses select 0 select 1;
 };
 private _buildingPos = _house buildingPos -1;
+_buildingPos = _buildingPos select [0, count _buildingPos min 20];
 private _pos_number = count _buildingPos - 1;
 private _pos = _buildingPos select (_pos_number - round random 1);
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/kill.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/kill.sqf
@@ -44,6 +44,7 @@ if (count _houses > 3) then {
     _house = _houses select 0 select 1;
 };
 private _buildingPos = _house buildingPos -1;
+_buildingPos = _buildingPos select [0, count _buildingPos min 20];
 private _pos_number = count _buildingPos - 1;
 private _pos = _buildingPos select (_pos_number - ((round random 1) min _pos_number));
 


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Cap the amount of enemy spawns for an assassination and hostage rescue mission (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
