### PR TITLE
FIX: Unit spawn in side are not link to the city of activation

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/EMP.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/EMP.sqf
@@ -72,7 +72,7 @@ for "_i" from 0 to (1 + round random 2) do {
         if (random 1 > 0.5) then {
             private _direction = random 360;
             private _statics = btc_type_gl + btc_type_mg;
-            [_pos getPos [5, _direction], _statics, _direction] call btc_fnc_mil_create_static;
+            [_pos getPos [5, _direction], _statics, _direction, [], _city] call btc_fnc_mil_create_static;
         };
     };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/checkpoint.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/checkpoint.sqf
@@ -79,10 +79,10 @@ for "_i" from 1 to (1 + round random 2) do {
     //// Create checkpoint with static at _pos \\\\
     _pos params ["_x", "_y", "_z"];
     private _posStatic = [_x -2.39185*cos(-_direction) - 2.33984*sin(-_direction), _y  + 2.33984 *cos(-_direction) -2.39185*sin(-_direction), _z];
-    [_posStatic, _statics, _direction + 180] call btc_fnc_mil_create_static;
+    [_posStatic, _statics, _direction + 180, [], _city] call btc_fnc_mil_create_static;
 
     private _posStatic = [_x + 2.72949*cos(-_direction) - -2.03857*sin(-_direction), _y -2.03857*cos(-_direction) +2.72949*sin(-_direction), _z];
-    [_posStatic, _statics, _direction] call btc_fnc_mil_create_static;
+    [_posStatic, _statics, _direction, [], _city] call btc_fnc_mil_create_static;
 
     _composition append ([_pos, _direction, _composition_checkpoint] call btc_fnc_create_composition);
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
@@ -66,6 +66,7 @@ private _group = [];
     [_unit] joinSilent _grp;
     _group pushBack _grp;
     _grp setVariable ["no_cache", true];
+    _grp setVariable ["btc_city", _city];
 } forEach (_buildingPos - [_pos]);
 
 _trigger = createTrigger ["EmptyDetector", _pos];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/kill.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/kill.sqf
@@ -78,6 +78,7 @@ private _group = [];
     [_unit] joinSilent _grp;
     _group pushBack _grp;
     _grp setVariable ["no_cache", true];
+    _grp setVariable ["btc_city", _city];
 } forEach (_buildingPos - [_pos]);
 
 _trigger = createTrigger ["EmptyDetector", _pos];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/tower.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/tower.sqf
@@ -52,8 +52,8 @@ private _btc_composition_tower = [
 
 //// Create tower with static at _pos \\\\
 private _statics = btc_type_gl + btc_type_mg;
-[_pos getPos [5, _direction], _statics, _direction] call btc_fnc_mil_create_static;
-[_pos getPos [- 5, _direction], _statics, _direction + 180] call btc_fnc_mil_create_static;
+[_pos getPos [5, _direction], _statics, _direction, [], _city] call btc_fnc_mil_create_static;
+[_pos getPos [- 5, _direction], _statics, _direction + 180, [], _city] call btc_fnc_mil_create_static;
 
 private _btc_composition = [_pos, _direction, _btc_composition_tower] call btc_fnc_create_composition;
 private _tower = _btc_composition select ((_btc_composition apply {typeOf _x}) find _tower_type);


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Unit spawn in side are not link to the city of activation (@Vdauphin).

**When merged this pull request will:**
- Peopllle are stupid enough to set player activation radius at 100m so when units created by side can appear at 100m if an other city have a caching radius overlapping the city of the side

**Final test:**
- [x] local
- [x] server

**Screenshots**
