### PR TITLE
Add: Change variable name for city radius

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -79,7 +79,7 @@ btc_p_autoloadout = "btc_p_autoloadout" call BIS_fnc_getParamValue;
 //<< Other options >>
 private _p_rep = "btc_p_rep" call BIS_fnc_getParamValue;
 btc_p_rep_notify = "btc_p_rep_notify" call BIS_fnc_getParamValue;
-private _p_city_radius = ("btc_p_city_radius" call BIS_fnc_getParamValue) * 100;
+private _p_city_radiusOffset = ("btc_p_city_radiusOffset" call BIS_fnc_getParamValue) * 100;
 btc_p_trigger = if (("btc_p_trigger" call BIS_fnc_getParamValue) isEqualTo 1) then {
     "this && (false in (thisList apply {_x isKindOf 'Plane'})) && (false in (thisList apply {(_x isKindOf 'Helicopter') && (speed _x > 190)}))"
 } else {
@@ -127,7 +127,7 @@ if (isServer) then {
     btc_delay_createUnit = 0;
 
     //City
-    btc_city_radius = _p_city_radius;
+    btc_city_radiusOffset = _p_city_radiusOffset;
     btc_city_blacklist = [];//NAME FROM CFG
 
     //Civ

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -389,7 +389,7 @@ class Params {
         texts[]={$STR_DISABLED, 0, 1, 2, 3, 5, 10, 25, 50, 100, 200};
         default = 3;
     };
-    class btc_p_city_radius { // Spawn city radius offset:
+    class btc_p_city_radiusOffset { // Spawn city radius offset:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_OTHER_SPAWNRAD"]);
         values[]={0,1,2,3,4,5,6,7,8};
         texts[]={"0 m","100 m","200 m",$STR_BTC_HAM_PARAM_OTHER_SPAWNRAD_DEF,"400 m","500 m (Takistan)","600 m","700 m","800 m"}; // texts[]={"0 m","100 m","200 m","300 m","400 m","500 m (Takistan)","600 m","700 m","800 m"};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/find_pos.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/find_pos.sqf
@@ -36,7 +36,7 @@ if (_city getVariable ["type", ""] in ["NameLocal", "Hill", "NameMarine"]) exitW
     [] call btc_cache_fnc_find_pos;
 };
 
-private _radius = _city getVariable ["radius", 200];
+private _radius = _city getVariable ["cachingRadius", 200];
 private _pos = [getPos _city, _radius] call btc_fnc_randomize_pos;
 private _houses = [_pos, 50] call btc_fnc_getHouses;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -53,11 +53,11 @@ _city setVariable ["active", true];
 private _data_units = _city getVariable ["data_units", []];
 private _data_animals = _city getVariable ["data_animals", []];
 private _type = _city getVariable ["type", ""];
-private _radius = _city getVariable ["radius", 100];
+private _cachingRadius = _city getVariable ["cachingRadius", 100];
 private _has_en = _city getVariable ["occupied", false];
 private _has_ho = _city getVariable ["has_ho", false];
 private _ieds = _city getVariable ["ieds", []];
-private _spawningRadius = _radius/2;
+private _spawningRadius = _cachingRadius/2;
 
 if (!(_city getVariable ["initialized", false])) then {
     private _ratio = (switch _type do {
@@ -201,7 +201,7 @@ if (
     (btc_cache_pos isNotEqualTo []) &&
     {!(btc_cache_obj getVariable ["btc_cache_unitsSpawned", false])}
 ) then {
-    if (_city inArea [btc_cache_pos, _radius, _radius, 0, false]) then {
+    if (_city inArea [btc_cache_pos, _cachingRadius, _cachingRadius, 0, false]) then {
         btc_cache_obj setVariable ["btc_cache_unitsSpawned", true];
 
         [btc_cache_pos, 8, 3, _wp_house] call btc_mil_fnc_create_group;
@@ -301,11 +301,11 @@ if (_civKilled isNotEqualTo []) then {
 };
 
 [{
-    params ["_has_en", "_city", "_radius", "_id"];
+    params ["_has_en", "_city", "_cachingRadius", "_id"];
 
     if (_has_en) then {
         private _trigger = createTrigger ["EmptyDetector", getPos _city, false];
-        _trigger setTriggerArea [_radius, _radius, 0, false];
+        _trigger setTriggerArea [_cachingRadius, _cachingRadius, 0, false];
         _trigger setTriggerActivation [str btc_enemy_side, "PRESENT", false];
         _trigger setTriggerStatements [btc_p_city_free_trigger_condition, format ["[%1, thisList] call btc_city_fnc_set_clear", _id], ""];
         _trigger setTriggerInterval 2;
@@ -313,7 +313,7 @@ if (_civKilled isNotEqualTo []) then {
     };
 
     _city setVariable ["activating", false];
-}, [_has_en, _city, _radius, _id], btc_delay_createUnit + _delay] call CBA_fnc_waitAndExecute;
+}, [_has_en, _city, _cachingRadius, _id], btc_delay_createUnit + _delay] call CBA_fnc_waitAndExecute;
 
 //Patrol
 btc_patrol_active = btc_patrol_active - [grpNull];
@@ -330,7 +330,7 @@ if (_numberOfPatrol < _p_patrol_max) then {
         private _group = createGroup btc_enemy_side;
         btc_patrol_active pushBack _group;
         _group setVariable ["no_cache", true];
-        [[_group, 1 + round random 1, _city, _radius + btc_patrol_area], btc_mil_fnc_create_patrol] call btc_delay_fnc_exec;
+        [[_group, 1 + round random 1, _city, _cachingRadius + btc_patrol_area], btc_mil_fnc_create_patrol] call btc_delay_fnc_exec;
     };
 };
 //Traffic
@@ -342,7 +342,7 @@ if (_numberOfCivVeh < _p_civ_max_veh) then {
         private _group = createGroup civilian;
         btc_civ_veh_active pushBack _group;
         _group setVariable ["no_cache", true];
-        [[_group, _city, _radius + btc_patrol_area], btc_civ_fnc_create_patrol] call btc_delay_fnc_exec;
+        [[_group, _city, _cachingRadius + btc_patrol_area], btc_civ_fnc_create_patrol] call btc_delay_fnc_exec;
     };
 };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/create.sqf
@@ -9,7 +9,7 @@ Parameters:
     _position - The position where the city will be created. [Array]
     _type - Type of city. [String]
     _name - The name of the city. [String]
-    _radius - The city radius. [Number]
+    _cachingRadius - The city radius. [Number]
     _has_en - If the city is occupied by enemies. [Boolean]
     _id - ID of the city in the cfgworlds. [Number]
 
@@ -30,7 +30,7 @@ params [
     ["_position", [0, 0, 0], [[]]],
     ["_type", "", [""]],
     ["_name", "", [""]],
-    ["_radius", 0, [0]],
+    ["_cachingRadius", 0, [0]],
     ["_has_en", false, [false]],
     ["_id", count btc_city_all, [0]]
 ];
@@ -41,7 +41,7 @@ _city setVariable ["activating", false];
 _city setVariable ["initialized", false];
 _city setVariable ["id", _id];
 _city setVariable ["name", _name];
-_city setVariable ["radius", _radius];
+_city setVariable ["cachingRadius", _cachingRadius];
 _city setVariable ["active", false];
 _city setVariable ["type", _type];
 _city setVariable ["spawn_more", false];
@@ -50,14 +50,14 @@ _city setVariable ["data_animals", []];
 _city setVariable ["occupied", _has_en];
 
 if (btc_p_sea) then {
-    _city setVariable ["hasbeach", ((selectBestPlaces [_position, 0.8 * _radius, "sea", 10, 1]) select 0 select 1) isEqualTo 1];
+    _city setVariable ["hasbeach", ((selectBestPlaces [_position, 0.8 * _cachingRadius, "sea", 10, 1]) select 0 select 1) isEqualTo 1];
 };
 
 [{
     (_this select 0) findEmptyPositionReady (_this select 1)
-}, {}, [_position, [0, _radius]], 5 * 60] call CBA_fnc_waitUntilAndExecute;
+}, {}, [_position, [0, _cachingRadius]], 5 * 60] call CBA_fnc_waitUntilAndExecute;
 
 btc_city_all set [_id, _city];
-[_position, _radius, _city, _has_en, _name, _type, _id] call btc_city_fnc_trigger_player_side;
+[_position, _cachingRadius, _city, _has_en, _name, _type, _id] call btc_city_fnc_trigger_player_side;
 
 _city

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/de_activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/de_activate.sqf
@@ -42,7 +42,7 @@ if !(_city getVariable ["active", false]) exitWith {};
     };
 
     //Save all and delete
-    private _radius = _city getVariable ["radius", 0];
+    private _cachingRadius = _city getVariable ["cachingRadius", 0];
     private _has_en = _city getVariable ["occupied", false];
 
     if (_has_en) then {
@@ -56,7 +56,7 @@ if !(_city getVariable ["active", false]) exitWith {};
     private _has_suicider = false;
     {
         if (
-            (leader _x) inArea [_pos_city, _radius, _radius, 0, false] &&
+            (leader _x) inArea [_pos_city, _cachingRadius, _cachingRadius, 0, false] &&
             {side _x != btc_player_side} &&
             {!(_x getVariable ["no_cache", false])} &&
             {_x getVariable ["btc_city", _city] in [_city, objNull]}
@@ -72,7 +72,7 @@ if !(_city getVariable ["active", false]) exitWith {};
     {
         private _agent = agent _x;
         if (
-            _agent inArea [_pos_city, _radius, _radius, 0, false] &&
+            _agent inArea [_pos_city, _cachingRadius, _cachingRadius, 0, false] &&
             {alive _agent} &&
             {!(_x getVariable ["no_cache", false])} &&
             {_x getVariable ["btc_city", _city] in [_city, objNull]}
@@ -98,7 +98,7 @@ if !(_city getVariable ["active", false]) exitWith {};
             ];
             _x call CBA_fnc_deleteEntity;
         };
-    } forEach (btc_tags_server inAreaArray [_pos_city, _radius, _radius]);
+    } forEach (btc_tags_server inAreaArray [_pos_city, _cachingRadius, _cachingRadius]);
     btc_tags_server = btc_tags_server - [objNull];
 
     (_city getVariable ["btc_city_intels", []]) call CBA_fnc_deleteEntity;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/init.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/init.sqf
@@ -58,8 +58,8 @@ for "_id" from 0 to (count _locations - 1) do {
             };
         };
         private _name = getText(_current >> "name");
-        private _radius = getNumber(_current >> "RadiusA") + getNumber(_current >> "RadiusB");
-        _radius = (_radius max 160) min 800;
+        private _cachingRadius = getNumber(_current >> "RadiusA") + getNumber(_current >> "RadiusB");
+        _cachingRadius = (_cachingRadius max 160) min 800;
 
         if (btc_city_blacklist find _name >= 0) exitWith {};
 
@@ -68,7 +68,7 @@ for "_id" from 0 to (count _locations - 1) do {
         if ((getMarkerPos "YOUR_MARKER_AREA") inArea [_position, 500, 500, 0, false]) exitWith {};
         */
 
-        [_position, _type, _name, _radius, random 1 > _is_free_probability, _id] call btc_city_fnc_create;
+        [_position, _type, _name, _cachingRadius, random 1 > _is_free_probability, _id] call btc_city_fnc_create;
     };
 };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_player_side.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/trigger_player_side.sqf
@@ -7,7 +7,7 @@ Description:
 
 Parameters:
     _position - Position where the trigger is created. [Array]
-    _radius - Radius of the location. [Number]
+    _cachingRadius - Radius of the location. [Number]
     _city - City object where the trigger will be stored. [Object]
     _has_en - City is occupied. [Boolean]
     _name - Name of the city. [String]
@@ -18,7 +18,7 @@ Returns:
 
 Examples:
     (begin example)
-        [_position, _radius, _city, _has_en, _name, _type, _id] call btc_city_fnc_trigger_player_side;
+        [_position, _cachingRadius, _city, _has_en, _name, _type, _id] call btc_city_fnc_trigger_player_side;
     (end)
 
 Author:
@@ -28,7 +28,7 @@ Author:
 
 params [
     ["_position", [0, 0, 0], [[]]],
-    ["_radius", 0, [0]],
+    ["_cachingRadius", 0, [0]],
     ["_city", objNull, [objNull]],
     ["_has_en", false, [false]],
     ["_name", "", [""]],
@@ -37,7 +37,7 @@ params [
 ];
 
 private _trigger = createTrigger ["EmptyDetector", _position, false];
-_trigger setTriggerArea [_radius + btc_city_radius, _radius + btc_city_radius, 0, false];
+_trigger setTriggerArea [_cachingRadius + btc_city_radiusOffset, _cachingRadius + btc_city_radiusOffset, 0, false];
 _trigger setTriggerActivation ["ANYPLAYER", "PRESENT", true];
 _trigger setTriggerStatements [btc_p_trigger, format ["[%1] call btc_city_fnc_activate", _id], format ["[%1] call btc_city_fnc_de_activate", _id]];
 _city setVariable ["trigger_player_side", _trigger];
@@ -46,7 +46,7 @@ if (btc_debug) then {
     private _marker = createMarker [format ["loc_%1", _id], _position];
     _marker setMarkerShape "ELLIPSE";
     _marker setMarkerBrush "SolidBorder";
-    _marker setMarkerSize [_radius + btc_city_radius, _radius + btc_city_radius];
+    _marker setMarkerSize [_cachingRadius + btc_city_radiusOffset, _cachingRadius + btc_city_radiusOffset];
     _marker setMarkerAlpha 0.3;
     if (_has_en) then {
         _marker setMarkerColor "colorRed";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/final_phase.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/final_phase.sqf
@@ -30,12 +30,12 @@ btc_city_remaining = [];
         if (_x getVariable ["marker", ""] != "") then {
             deleteMarker (_x getVariable ["marker", ""]);
         };
-        private _radius = _x getVariable ["radius", 500];
+        private _cachingRadius = _x getVariable ["cachingRadius", 500];
 
         private _marker = createMarker [format ["city_%1", position _x], position _x];
         _marker setMarkerShape "ELLIPSE";
         _marker setMarkerBrush "SolidBorder";
-        _marker setMarkerSize [_radius, _radius];
+        _marker setMarkerSize [_cachingRadius, _cachingRadius];
         _marker setMarkerAlpha 0.3;
         if (_x getVariable ["occupied", false]) then {
             _marker setMarkerColor "colorRed";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/hideout/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/hideout/create.sqf
@@ -63,8 +63,8 @@ if (_pos isEqualTo []) then {
         _city = selectRandom _usefulRange;
     };
 
-    private _radius = _city getVariable ["radius", 0];
-    private _random_pos = [getPos _city, _radius/2] call btc_fnc_randomize_pos;
+    private _cachingRadius = _city getVariable ["cachingRadius", 0];
+    private _random_pos = [getPos _city, _cachingRadius/2] call btc_fnc_randomize_pos;
     _pos = [_random_pos, 0, 100, 2, false] call btc_fnc_findsafepos;
 
     _id = _city getVariable ["id", 0];
@@ -83,7 +83,7 @@ deleteVehicle (_city getVariable ["trigger_player_side", objNull]);
 [_pos, btc_hideouts_radius, _city, _city getVariable "occupied", _city getVariable "name", _city getVariable "type", _city getVariable "id"] call btc_city_fnc_trigger_player_side;
 [{
     (_this select 0) findEmptyPositionReady (_this select 1)
-}, {}, [_pos, [0, _city getVariable ["radius", 100]]], 5 * 60] call CBA_fnc_waitUntilAndExecute;
+}, {}, [_pos, [0, _city getVariable ["cachingRadius", 100]]], 5 * 60] call CBA_fnc_waitUntilAndExecute;
 
 private _hideout = [_pos] call btc_hideout_fnc_create_composition;
 clearWeaponCargoGlobal _hideout;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_patrol.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_patrol.sqf
@@ -58,7 +58,7 @@ if (_usefuls isEqualTo []) exitWith {
 private _start_city = selectRandom _usefuls;
 private _pos = [];
 if (_start_city getVariable ["hasbeach", false]) then {
-    _pos = [getPos _start_city, _start_city getVariable ["radius", 100], btc_p_sea] call btc_fnc_randomize_pos;
+    _pos = [getPos _start_city, _start_city getVariable ["cachingRadius", 100], btc_p_sea] call btc_fnc_randomize_pos;
 } else {
     _pos = getPos _start_city;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/patrol/init.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/patrol/init.sqf
@@ -42,7 +42,7 @@ private _end_city = selectRandom ([[_start_city, _active_city], _area, _isBoat] 
 
 private _pos = getPos _end_city;
 if (_isBoat) then {
-    ((selectBestPlaces [_pos, _end_city getVariable ["radius", 100], "sea", 10, 1]) select 0 select 0) params ["_x", "_y"];
+    ((selectBestPlaces [_pos, _end_city getVariable ["cachingRadius", 100], "sea", 10, 1]) select 0 select 0) params ["_x", "_y"];
     _pos = [_x, _y, 0];
 };
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/EMP.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/EMP.sqf
@@ -32,7 +32,7 @@ private _city = selectRandom _useful;
 
 _city setVariable ["spawn_more", true];
 
-private _radius = _city getVariable ["radius", 0];
+private _radius = _city getVariable ["cachingRadius", 0];
 private _composition = [];
 private _tasksID = [];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/capture_officer.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/capture_officer.sqf
@@ -36,7 +36,7 @@ if (_usefuls isEqualTo []) exitWith {[] spawn btc_side_fnc_create;};
 private _city1 = selectRandom _usefuls;
 
 //// Find Road \\\\
-private _radius = (_city1 getVariable ["radius", 0])/2;
+private _radius = (_city1 getVariable ["cachingRadius", 0])/2;
 private _roads = _city1 nearRoads (_radius * 2);
 _roads = _roads select {(_x distance _city1 > _radius) && isOnRoad _x};
 if (_roads isEqualTo []) exitWith {[] spawn btc_side_fnc_create;};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/checkpoint.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/checkpoint.sqf
@@ -35,7 +35,7 @@ private _pos = getPos _city;
 _city setVariable ["spawn_more", true];
 
 private _statics = btc_type_gl + btc_type_mg;
-private _radius = _city getVariable ["radius", 0];
+private _radius = _city getVariable ["cachingRadius", 0];
 
 private _boxes = [];
 private _composition = [];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/chemicalLeak.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/chemicalLeak.sqf
@@ -28,7 +28,7 @@ private _useful = btc_city_all select {!(isNull _x) && !(_x getVariable ["occupi
 if (_useful isEqualTo []) then {_useful = + (btc_city_all select {!(isNull _x)});};
 
 private _city = selectRandom _useful;
-private _pos = [getPos _city, 0, _city getVariable ["radius", 100], 30, false] call btc_fnc_findsafepos;
+private _pos = [getPos _city, 0, _city getVariable ["cachingRadius", 100], 30, false] call btc_fnc_findsafepos;
 
 [_taskID, 30, getPos _city, _city getVariable "name"] call btc_task_fnc_create;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/convoy.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/convoy.sqf
@@ -36,7 +36,7 @@ if (_usefuls isEqualTo []) exitWith {[] spawn btc_side_fnc_create;};
 private _city1 = selectRandom _usefuls;
 
 //// Find Road \\\\
-private _radius = (_city1 getVariable ["radius", 0])/2;
+private _radius = (_city1 getVariable ["cachingRadius", 0])/2;
 private _roads = _city1 nearRoads (_radius * 2);
 _roads = _roads select {(_x distance _city1 > _radius) && isOnRoad _x};
 if (_roads isEqualTo []) exitWith {[] spawn btc_side_fnc_create;};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/mines.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/mines.sqf
@@ -28,7 +28,7 @@ private _useful = btc_city_all select {!(isNull _x) && !((_x getVariable ["type"
 if (_useful isEqualTo []) then {_useful = + (btc_city_all select {!(isNull _x)});};
 
 private _city = selectRandom _useful;
-private _pos = [getPos _city, 0, _city getVariable ["radius", 100], 30, false] call btc_fnc_findsafepos;
+private _pos = [getPos _city, 0, _city getVariable ["cachingRadius", 100], 30, false] call btc_fnc_findsafepos;
 if (_pos select 2 > 50) exitWith {[] spawn btc_side_fnc_create;};
 
 [_taskID, 4, _pos, _city getVariable "name"] call btc_task_fnc_create;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
@@ -32,7 +32,7 @@ if (_useful isEqualTo []) exitWith {[] spawn btc_side_fnc_create;};
 private _city = selectRandom _useful;
 
 //// Randomise position \\\\
-private _pos = [getPos _city, (_city getVariable ["radius", 0])/2 - 100] call btc_fnc_randomize_pos;
+private _pos = [getPos _city, (_city getVariable ["cachingRadius", 0])/2 - 100] call btc_fnc_randomize_pos;
 _pos = [_pos, 0, 50, 13, 0, 60 * (pi / 180), 0] call btc_fnc_findsafepos;
 
 _city setVariable ["spawn_more", true];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/supply.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/supply.sqf
@@ -30,7 +30,7 @@ if (_useful isEqualTo []) then {_useful = + (btc_city_all select {!(isNull _x)})
 
 private _city = selectRandom _useful;
 private _pos = [getPos _city, 100] call btc_fnc_randomize_pos;
-_pos = [_pos, 0, _city getVariable ["radius", 100], 20, false] call btc_fnc_findsafepos;
+_pos = [_pos, 0, _city getVariable ["cachingRadius", 100], 20, false] call btc_fnc_findsafepos;
 
 [_taskID, 3, getPos _city, _city getVariable "name"] call btc_task_fnc_create;
 private _move_taskID = _taskID + "mv";


### PR DESCRIPTION
<!-- Use English only. -->

- Add: Change variable name for city radius (@Vdauphin).

**When merged this pull request will:**
- title
- Make the radius name varaible more understandable
- `radius` --> `cachingRadius`, ie all AI in this radius will be cached on city desactivation
- `btc_city_radius` --> `btc_city_radiusOffset`, offset added to the cachingRadius so AI don't spawn in front of people.

**Final test:**
- [x] local
- [x] server

**Screenshots**
