### PR TITLE
FIX: Error _wp_ratios is not define anymore

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_group.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_group.sqf
@@ -100,7 +100,7 @@ for "_i" from 1 to _numberOfGroup do {
 };
 
 if (btc_debug_log) then {
-    [format ["_this = %1 ; POS %2 UNITS N %3 _wp_ratios %4", _this, _pos, _n, _wp_ratios], __FILE__, [false]] call btc_debug_fnc_message;
+    [format ["_this = %1 ; POS %2 UNITS N %3", _this, _pos, _n], __FILE__, [false]] call btc_debug_fnc_message;
 };
 
 _groups


### PR DESCRIPTION
<!-- Use English only. -->

- ignore changelog.

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
