### PR TITLE
FIX: Side rescue give you reputation even when this mission fail

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
@@ -155,7 +155,7 @@ if (_units select {alive _x} isEqualTo []) then {
 } forEach _triggers;
 [[], [_heli, _fx, _group] + _units] call btc_fnc_delete;
 
-if (_taskID call BIS_fnc_taskState in ["CANCELED", "FAIL"]) exitWith {};
+if (_taskID call BIS_fnc_taskState in ["CANCELED", "FAILED"]) exitWith {};
 
 _rep call btc_fnc_rep_change;
 


### PR DESCRIPTION

<!-- Use English only. -->

- FIX: Side rescue give you reputation even when this mission fail (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
