### PR TITLE
FIX: Unaccurate execution order when vehicles are created

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/delay/createVehicle.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/delay/createVehicle.sqf
@@ -31,6 +31,8 @@ Author:
 btc_delay_createUnit = btc_delay_createUnit + 0.3;
 
 [{
+    btc_delay_createUnit = btc_delay_createUnit - 0.3;
+
     params [
         ["_group", grpNull, [grpNull]],
         ["_vehicle_type", "", [""]],
@@ -83,7 +85,6 @@ btc_delay_createUnit = btc_delay_createUnit + 0.3;
     };
 
     ["btc_delay_vehicleInit", [_veh, _group]] call CBA_fnc_localEvent;
-    btc_delay_createUnit = btc_delay_createUnit - 0.3;
 }, _this, btc_delay_createUnit - 0.01] call CBA_fnc_waitAndExecute;
 
 count (_this select 2) * 0.3


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Unaccurate execution order when vehicles are created (@Vdauphin).

**When merged this pull request will:**
- title
- may fix some weird issue with crew spawning outside for headless

**Final test:**
- [x] local
- [x] server

**Screenshots**
