### PR TITLE
FIX: Ensure only players trigger hideout destruction

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/hd_hideout.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/hd_hideout.sqf
@@ -41,7 +41,8 @@ private _explosive = getNumber(configFile >> "cfgAmmo" >> _ammo >> "explosive") 
 if (
     _explosive &&
     {!(_hideout getVariable ["btc_fnc_mil_hd_hideout_fired", false])} &&
-    {_damage > 0.6}
+    {_damage > 0.6} &&
+    {isPlayer [_instigator]}
 ) then {
     _hideout setVariable ["btc_fnc_mil_hd_hideout_fired", true];
 


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Ensure only players trigger hideout destruction (@Vdauphin).

**When merged this pull request will:**
- title
- [x] need ACE 3.14.1 https://github.com/acemod/ACE3/pull/8647

**Final test:**
- [x] local
- [x] server

**Screenshots**
