### PR TITLE
FIX: Waypoints for drone and suicider take 15ms

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/drone_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/drone_create.sqf
@@ -44,7 +44,7 @@ createVehicleCrew _drone;
 [driver _drone] joinSilent _group;
 _group setVariable ["btc_ied_drone", true];
 
-[_group, _rpos, _area, 4] call CBA_fnc_taskPatrol;
+[[_group, _rpos, _area, 4], CBA_fnc_taskPatrol] call btc_delay_fnc_exec;
 _drone flyInHeight 10;
 
 [driver _drone, _rpos, _area, []] call btc_ied_fnc_droneLoop;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_create.sqf
@@ -46,7 +46,7 @@ private _group = createGroup [civilian, true];
 _group setVariable ["btc_city", _city];
 private _suicider = _group createUnit [_type_units, _rpos, [], 0, "CAN_COLLIDE"];
 
-[_group] call btc_civ_fnc_addWP;
+[_group, btc_civ_fnc_addWP] call btc_delay_fnc_exec;
 _group setVariable ["suicider", true];
 
 [_suicider] call btc_ied_fnc_suiciderLoop;


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Waypoints for drone and suicider take 15ms (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
