### PR TITLE
FIX: Some weapon have dummy magazine creating error by picking them from inventory

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/inventoryGet.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/inventoryGet.sqf
@@ -29,9 +29,17 @@ private _everyContainer = everyContainer _object;
     _x set [1, (_x select 1) call btc_log_fnc_inventoryGet];
 } forEach _everyContainer;
 
+private _weaponsItemsCargo = weaponsItemsCargo _object;
+{
+    private _magazine = _x select 4 select 0;
+    if (((_magazine call BIS_fnc_itemType) select 1) isEqualTo "UnknownMagazine") then {
+        _x set [4, []]; // Remove dummy magazine
+    };
+} forEach _weaponsItemsCargo;
+
 [
     getMagazineCargo _object,
-    weaponsItemsCargo _object,
+    _weaponsItemsCargo,
     itemCargo _object,
     _everyContainer
 ]


### PR DESCRIPTION

<!-- Use English only. -->

- ignore


**When merged this pull request will:**
- title
- [x] for normal weapon if everything goes well
- Spectrum device have dummy magazine whitch create an error when picking from an inventory after a saving

**Final test:**
- [x] local
- [x] server

**Screenshots**
