### PR TITLE
FIX: Hideout may cook off and destroy the hideout ammo box

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/hideout/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/hideout/create.sqf
@@ -97,6 +97,7 @@ _hideout setVariable ["cap_time", _cap_time];
 _hideout setVariable ["assigned_to", _city];
 
 _hideout addEventHandler ["HandleDamage", btc_hideout_fnc_hd];
+_hideout setVariable ["ace_cookoff_enable", false, true];
 
 private _markers = [];
 {


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Hideout may cook off and destroy the hideout ammo box (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
