### PR TITLE
FIX: Hack side mission could use an `objNull` as city

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hack.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hack.sqf
@@ -65,7 +65,7 @@ private _defend_taskID = _taskID + "df";
 [[_defend_taskID, _taskID], 22, _terminal, _terminalType, true] call btc_task_fnc_create;
 
 private _groups = [];
-private _closest = [_city, btc_city_all select {!(_x getVariable ["active", false])}, false] call btc_fnc_find_closecity;
+private _closest = [_city, btc_city_all select {!isNull _x && !(_x getVariable ["active", false])}, false] call btc_fnc_find_closecity;
 for "_i" from 1 to (2 + round random 1) do {
     _groups pushBack ([btc_mil_fnc_send, [_closest, getPos _terminal, 1, selectRandom btc_type_motorized]] call CBA_fnc_directCall);
 };


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Hack side mission could use an `objNull` as city (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [ ] local
- [ ] server

**Screenshots**
