### PR TITLE
FIX: Can't set number of hideout above 5 in mission parameters

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -229,7 +229,7 @@ class Params {
     };
     class btc_p_hideout_n { // Hideout numbers:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_HIDE_NUMBERS"]);
-        values[]={99,0,1,2,3,4,5};
+        values[]={99,0,1,2,3,4,5,6,7,8,9,10};
         texts[]={$STR_3DEN_ATTRIBUTES_OBJECTTEXTURE_RANDOM_TEXT,"0","1","2","3","4","5","6","7","8","9","10"}; //texts[]={"Random","0","1","2","3","4","5"};
         default = 5;
     };


### PR DESCRIPTION


<!-- Use English only. -->

- FIX: Can't set number of hideout above 5 in mission parameters (@Vdauphin).

**When merged this pull request will:**
- title
- The default value is not present so we can't define value above 5 hideout

**Final test:**
- [x] local
- [x] server

**Screenshots**
