### PR TITLE
FIX: Towing say Not align when vehicles were align but too close to each other

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tow/check.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/tow/check.sqf
@@ -49,7 +49,7 @@ if (_pos_rearTower distance _pos_frontTowed > 5) exitWith {
     false
 };
 if (
-    !([_pos_rearTower, ((getDir _tower) + 180) mod 360, 100, _pos_frontTowed] call BIS_fnc_inAngleSector)
+    !([position _tower, ((getDir _tower) + 180) mod 360, 90, _pos_frontTowed] call BIS_fnc_inAngleSector)
 ) exitWith {
     (localize "STR_BTC_HAM_TOW_NOTA") call CBA_fnc_notify;
     false


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Towing say Not align when vehicles were align but too close to each other (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
