### PR TITLE
FIX: Disable debug teleport when on respawn screen

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_player.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_player.sqf
@@ -42,7 +42,16 @@ btc_intro_done = [] spawn btc_respawn_fnc_intro;
     [] call btc_respawn_fnc_screen;
 
     if (btc_debug) then {
-        onMapSingleClick "vehicle player setPos _pos";
+        addMissionEventHandler ["MapSingleClick", {
+            params ["_units", "_pos", "_alt", "_shift"];
+            if (
+                alive player &&
+                !_alt &&
+                !_shift
+            ) then {
+                vehicle player setPos _pos;
+            };
+        }];
         player allowDamage false;
 
         [{!isNull (findDisplay 12)}, {


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Disable debug teleport when on respawn screen (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
