### PR TITLE
FIX: Some player may not get respawn tickets on heavy modded server

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/respawn/playerConnected.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/respawn/playerConnected.sqf
@@ -34,4 +34,4 @@ if (_name isEqualTo "__SERVER__") exitWith {};
         _this call BIS_fnc_getUnitByUID,
         _tickets
     ] call BIS_fnc_respawnTickets;
-}, _uid, 4 * 60] call CBA_fnc_waitUntilAndExecute;
+}, _uid, 20 * 60] call CBA_fnc_waitUntilAndExecute;


### PR DESCRIPTION


<!-- Use English only. -->

- FIX: Some player may not get tickets on heavy modded server (@Vdauphin).

**When merged this pull request will:**
- title
- Give enough time (20min) for player to connect on heavy moded server before it was 4min

**Final test:**
- [x] local
- [x] server

**Screenshots**
