### PR TITLE
FIX: Player's ticket saved is wrong after processing a prisoner for player who never died

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/respawn/addTicket.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/respawn/addTicket.sqf
@@ -45,5 +45,5 @@ if !(_player isEqualTo objNull) then {
 
 if (_uid isEqualTo "") exitWith {};
 
-private _ticketValue = _ticket + (btc_respawn_tickets getOrDefault [_uid, 0]);
+private _ticketValue = _ticket + (btc_respawn_tickets getOrDefault [_uid, btc_p_respawn_ticketsAtStart]);
 btc_respawn_tickets set [_uid, _ticketValue];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/respawn/playerConnected.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/respawn/playerConnected.sqf
@@ -42,4 +42,4 @@ if (btc_debug_log) then {
     if (btc_debug_log) then {
         [format ["_respawnTickets %1 _tickets %2 _uid %3", _respawnTickets, _tickets, _this], __FILE__, [false]] call btc_debug_fnc_message;
     };
-}, _uid, 20 * 60] call CBA_fnc_waitUntilAndExecute;
+}, _uid, 4 * 60] call CBA_fnc_waitUntilAndExecute;


### PR DESCRIPTION


<!-- Use English only. -->

- FIX: Player's ticket saved is wrong after processing a prisoner for player who never died (@Vdauphin).

**When merged this pull request will:**
- title
- When a player never die but get new tickets with prisoner, the value saved in `btc_respawn_tickets` was wrong because it was using the default value `0` and not the default `btc_p_respawn_ticketsAtStart`

**Final test:**
- [x] local
- [x] server

**Screenshots**
Before fix
![20220423134414_1](https://user-images.githubusercontent.com/14364400/164893450-164df4e5-e9e3-42ba-87c3-6d35d82ef180.jpg)

After fix
![20220423134648_1](https://user-images.githubusercontent.com/14364400/164893454-927931f4-6ea3-4804-bf58-559b93ec8728.jpg)

