### PR TITLE
FIX: Static spawn on hideout's objects when no house is detected around

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/getHouses.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/getHouses.sqf
@@ -37,7 +37,13 @@ private _notEnterable = [];
             _x isKindOf "Lamps_base_F" ||
             {_x isKindOf "PowerLines_Small_base_F"} ||
             {_x isKindOf "PowerLines_Wires_base_F"} ||
-            {_x isKindOf "Wall"}
+            {_x isKindOf "Wall"} ||
+            {_x isKindOf "Camping_base_F"} ||
+            {_x isKindOf "Land_Campfire_F"} ||
+            {_x isKindOf "Land_MetalBarrel_empty_F"} ||
+            {_x isKindOf "FlagCarrierCore"} ||
+            {_x isKindOf "Scrapyard_base_F"} ||
+            {_x isKindOf "Shelter_base_F"}
         ) then {continue;};
         _notEnterable pushBack _x;
     } else {


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Static spawn on hideout's objects when no house is detected around (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
