### PR TITLE
FIX: Body bag marker stay after wreck repaired with dead body inside

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/body/bagRecover_s.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/body/bagRecover_s.sqf
@@ -53,4 +53,5 @@ if (btc_p_respawn_ticketsShare) then {
     };
 };
 
+deleteMarker (_bodyBag getVariable ["btc_body_deadMarker", ""]);
 _bodyBag call CBA_fnc_deleteEntity;


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Body bag marker stay after wreck repaired with dead body inside (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
