### PR TITLE
Chemical detector fix

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/ehDetector.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/ehDetector.sqf
@@ -26,7 +26,7 @@ Author:
         params ["_display", "_key"];
 
         if (
-            _key in actionKeys "Watch" &&
+            (_key in actionKeys "Watch" || _key in actionKeys "WatchToggle") &&
             {!visibleWatch} &&
             {"ChemicalDetector_01_watch_F" in (assignedItems player)}
         ) then {


### PR DESCRIPTION
- FIX: chemical detector not updating when using the Watch (Toggle) keybind

**When merged this pull request will:**
- Fix the chemical detector not updating when using the Watch (Toggle) keybind.

**Final test:**
- [ ] local
- [x] server

**Screenshots**
Not applicable
