### PR TITLE
Add: CBA Extended Loadouts

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/slot/deserializeState.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/slot/deserializeState.sqf
@@ -43,7 +43,7 @@ Author:
         player distance ASLToAGL _previousPos > 50 || // Don't set loadout when near main base
         btc_p_autoloadout isEqualTo 0
     ) then { 
-        [{player setUnitLoadout _this;}, _loadout] call CBA_fnc_execNextFrame;
+        [{[player, _this] call CBA_fnc_setLoadout;}, _loadout] call CBA_fnc_execNextFrame;
     };
     if ((isNull _vehicle) || {!(player moveInAny _vehicle)}) then {
         player setPosASL _previousPos;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/slot/serializeState.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/slot/serializeState.sqf
@@ -28,14 +28,9 @@ if (
     isNil {_unit getVariable "btc_slot_key"}
 ) exitWith {};
 
-private _loadout = getUnitLoadout _unit;
+private _loadout = [_unit] call CBA_fnc_getLoadout;
 if (["acre_api"] call ace_common_fnc_isModLoaded) then {
     _loadout = [_loadout] call acre_api_fnc_filterUnitLoadout;
-};
-
-// Add earplugs to uniform if has them plugged in (temporary until Variables support)
-if (_unit call ace_hearing_fnc_hasEarPlugsIn && {!((_loadout select 3) isEqualTo [])}) then {
-    ((_loadout select 3) select 1) pushBack ["ACE_EarPlugs", 1];
 };
 
 private _data = [


### PR DESCRIPTION
<!-- Use English only. -->

- Add: CBA Extended Loadouts (@Vdauphin).

**When merged this pull request will:**
~- [ ] wait for https://github.com/IDI-Systems/acre2/pull/1205 and remove :~ 
```sqf
if (["acre_api"] call ace_common_fnc_isModLoaded) then {
    _loadout = [_loadout] call acre_api_fnc_filterUnitLoadout;
};
```
- [x] need https://github.com/acemod/ACE3/pull/9041

**Final test:**
- [x] local
- [x] server

**Screenshots**
