### PR TITLE
FIX: Side civilian need help only have hematoma since ACE 3.15.1

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/set_damage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/set_damage.sqf
@@ -42,7 +42,7 @@ private _type = [
 _unit setVariable ["ace_medical_ai_lastFired", 9999999]; //Disable AI to self healing
 
 for "_i" from 0 to (1 + floor random 2) do {
-    [_unit, 0.2, selectRandom _selection, selectRandom _type] call ace_medical_fnc_addDamageToUnit;
+    [_unit, 0.4, selectRandom _selection, selectRandom _type] call ace_medical_fnc_addDamageToUnit;
     sleep 1;
 };
 


### PR DESCRIPTION

<!-- Use English only. -->

- FIX: Side civilian need help only have hematoma since ACE 3.15.1 (@Vdauphin).

**When merged this pull request will:**
- title
- fix https://github.com/Vdauphin/HeartsAndMinds/issues/1424

**Final test:**
- [x] local
- [x] server

**Screenshots**
