### PR TITLE
Add: Increase the base number of civilian per type of city

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -189,7 +189,7 @@ class Params {
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_CIVILIAN_DENSITY"]);
         values[]={0,10,20,30,40,50,60,70,80,90,100};
         texts[]={"0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"};
-        default = 100;
+        default = 50;
     };
     class btc_p_animals_group_ratio { // Animal density:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_ANIMALS_DENSITY"]);

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/city/activate.sqf
@@ -143,15 +143,15 @@ if (_data_units isNotEqualTo []) then {
 
         // Spawn civilians
         private _numberOfCivi = (switch _type do {
-            case "VegetationFir" : {1};
+            case "VegetationFir" : {2};
             case "BorderCrossing" : {0};
-            case "NameLocal" : {3};
+            case "NameLocal" : {6};
             case "StrongpointArea" : {0};
-            case "NameVillage" : {6};
-            case "NameCity" : {10};
-            case "NameCityCapital" : {19};
-            case "Airport" : {6};
-            default {2};
+            case "NameVillage" : {12};
+            case "NameCity" : {20};
+            case "NameCityCapital" : {38};
+            case "Airport" : {12};
+            default {4};
         });
         [+_housesEntrerable, round (_p_civ_group_ratio * _numberOfCivi), _city] call btc_civ_fnc_populate;
     };


### PR DESCRIPTION
<!-- Use English only. -->

- Add: Increase the base number of civilian per type of city (@Vdauphin).

**When merged this pull request will:**
- title
- Keep the default value by putting 50% as default

**Final test:**
- [x] local
- [x] server

**Screenshots**
