### PR TITLE
FIX: Player in respawn screen don't get their ticket from prisoner

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/body/bagRecover_s.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/body/bagRecover_s.sqf
@@ -46,7 +46,7 @@ if (btc_p_respawn_ticketsShare) then {
         private _player = _UID call BIS_fnc_getUnitByUID;
         [_player, _ticket, _UID] call btc_respawn_fnc_addTicket;
     } else {
-        private _players = (units btc_player_side) select {isPlayer _x};
+        private _players = allPlayers select {side group _x isEqualTo btc_player_side};
         {
             [_x, _ticket, getPlayerUID _x] call btc_respawn_fnc_addTicket;
         } forEach _players;


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Player in respawn screen don't get their ticket (@Vdauphin).

**When merged this pull request will:**
- title
- `units` don't return player while dead for no reason

**Final test:**
- [x] local
- [x] server

**Screenshots**
