### PR TITLE
FIX: Vehicle orientation is wrong when spawn with garage 

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/arsenal/garage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/arsenal/garage.sqf
@@ -51,7 +51,7 @@ with uiNamespace do {
     {
         private _type = typeOf _x;
         private _pos = getPosASL _x;
-        private _dir = getDir _x;
+        private _dir = getDir _current_garage;
         private _customization = [_x] call BIS_fnc_getVehicleCustomization;
 
         _x call CBA_fnc_deleteEntity;


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Vehicle orientation is wrong when spawn with garage (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
