### PR TITLE
FIX: Player not teleported inside the last vehicle occupied after server restart if vehicle have moved

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/save.sqf
@@ -234,7 +234,11 @@ private _slots_serialized = +btc_slots_serialized;
         [format ["btc_slots_serialized %1 %2", _x, _y], __FILE__, [false]] call btc_debug_fnc_message;
     };
     if (_y isEqualTo []) then {continue};
-    _y set [6, typeOf (_y select 6)];
+    private _vehicle = _y select 6;
+    if !(isNull _vehicle) then {
+        _y set [0, getPosASL _vehicle];
+    };
+    _y set [6, typeOf _vehicle];
 } forEach _slots_serialized;
 profileNamespace setVariable [format ["btc_hm_%1_slotsSerialized", _name], +_slots_serialized];
 


### PR DESCRIPTION

<!-- Use English only. -->

- ignore change log

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
