### PR TITLE
Add: Select the power of IED in mission parameters

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -43,6 +43,7 @@ btc_p_ied = ("btc_p_ied" call BIS_fnc_getParamValue)/2;
 private _p_ied_spot = "btc_p_ied_spot" call BIS_fnc_getParamValue;
 btc_p_ied_placement = "btc_p_ied_placement" call BIS_fnc_getParamValue;
 btc_p_ied_drone = ("btc_p_ied_drone" call BIS_fnc_getParamValue) isEqualTo 1;
+btc_p_ied_boom = "btc_p_ied_boom" call BIS_fnc_getParamValue;
 
 //<< Hideout/Cache options >>
 btc_hideout_n = "btc_p_hideout_n" call BIS_fnc_getParamValue;
@@ -167,6 +168,7 @@ if (isServer) then {
     btc_ied_offset = [0, -0.03, -0.07] select _p_ied_spot;
     btc_ied_list = [];
     btc_ied_range = 10;
+	btc_ied_boom = ["Bo_GBU12_LGB_MI10", "R_MRAAWS_HE_F"] select btc_p_ied_boom;
 
     //FOB
     btc_fobs = [[], [], []];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -43,7 +43,7 @@ btc_p_ied = ("btc_p_ied" call BIS_fnc_getParamValue)/2;
 private _p_ied_spot = "btc_p_ied_spot" call BIS_fnc_getParamValue;
 btc_p_ied_placement = "btc_p_ied_placement" call BIS_fnc_getParamValue;
 btc_p_ied_drone = ("btc_p_ied_drone" call BIS_fnc_getParamValue) isEqualTo 1;
-btc_p_ied_boom = "btc_p_ied_boom" call BIS_fnc_getParamValue;
+btc_p_ied_power = "btc_p_ied_power" call BIS_fnc_getParamValue;
 
 //<< Hideout/Cache options >>
 btc_hideout_n = "btc_p_hideout_n" call BIS_fnc_getParamValue;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -168,7 +168,7 @@ if (isServer) then {
     btc_ied_offset = [0, -0.03, -0.07] select _p_ied_spot;
     btc_ied_list = [];
     btc_ied_range = 10;
-    btc_ied_boom = ["Bo_GBU12_LGB_MI10", "R_MRAAWS_HE_F"] select btc_p_ied_boom;
+    btc_ied_power = ["Bo_GBU12_LGB_MI10", "R_MRAAWS_HE_F"] select btc_p_ied_power;
 
     //FOB
     btc_fobs = [[], [], []];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -168,7 +168,7 @@ if (isServer) then {
     btc_ied_offset = [0, -0.03, -0.07] select _p_ied_spot;
     btc_ied_list = [];
     btc_ied_range = 10;
-	btc_ied_boom = ["Bo_GBU12_LGB_MI10", "R_MRAAWS_HE_F"] select btc_p_ied_boom;
+    btc_ied_boom = ["Bo_GBU12_LGB_MI10", "R_MRAAWS_HE_F"] select btc_p_ied_boom;
 
     //FOB
     btc_fobs = [[], [], []];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -251,7 +251,7 @@ class Params {
         texts[]={$STR_BTC_HAM_PARAM_IED_PLACEMENT_ROADSIDE,$STR_BTC_HAM_PARAM_IED_PLACEMENT_MIDDLE,$STR_3DEN_ATTRIBUTES_OBJECTTEXTURE_RANDOM_TEXT}; //texts[]={"Roadside", "Middle", "Random"};
         default = 3;
     };
-	class btc_p_ied_boom { // Type of explosion:
+	class btc_p_ied_power { // Power of IED explosion:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_IED_BOOM"]);
         values[]={0, 1};
         texts[]={$STR_MEDIUM,$STR_SMALL};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -252,7 +252,7 @@ class Params {
         default = 3;
     };
 	class btc_p_ied_power { // Power of IED explosion:
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_IED_BOOM"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_IED_POWER"]);
         values[]={0, 1};
         texts[]={$STR_MEDIUM,$STR_SMALL};
         default = 0;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -252,7 +252,7 @@ class Params {
         default = 3;
     };
 	class btc_p_ied_boom { // Type of explosion:
-        title = __EVAL(format ["      %1", "type d'explosion"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_IED_BOOM"]);
         values[]={0, 1};
         texts[]={"Big","Small"};
         default = 0;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -254,7 +254,7 @@ class Params {
 	class btc_p_ied_boom { // Type of explosion:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_IED_BOOM"]);
         values[]={0, 1};
-        texts[]={"Big","Small"};
+        texts[]={$STR_MEDIUM,$STR_SMALL};
         default = 0;
 	};
     class btc_p_ied_drone { // Drone bomber:

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -251,6 +251,12 @@ class Params {
         texts[]={$STR_BTC_HAM_PARAM_IED_PLACEMENT_ROADSIDE,$STR_BTC_HAM_PARAM_IED_PLACEMENT_MIDDLE,$STR_3DEN_ATTRIBUTES_OBJECTTEXTURE_RANDOM_TEXT}; //texts[]={"Roadside", "Middle", "Random"};
         default = 3;
     };
+	class btc_p_ied_boom { // Type of explosion:
+        title = __EVAL(format ["      %1", "type d'explosion"]);
+        values[]={0, 1};
+        texts[]={"Big","Small"};
+        default = 0;
+	};
     class btc_p_ied_drone { // Drone bomber:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_IED_DRONE"]);
         values[]={0, 1};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/boom.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/boom.sqf
@@ -32,7 +32,7 @@ if (btc_debug_log) then {
 
 private _pos = getPos _ied;
 deleteVehicle _ied;
-"Bo_GBU12_LGB_MI10" createVehicle _pos;
+btc_ied_boom createVehicle _pos;
 deleteVehicle _wreck;
 
 [_pos] call btc_deaf_fnc_earringing;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/boom.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/boom.sqf
@@ -32,7 +32,7 @@ if (btc_debug_log) then {
 
 private _pos = getPos _ied;
 deleteVehicle _ied;
-btc_ied_boom createVehicle _pos;
+btc_ied_power createVehicle _pos;
 deleteVehicle _wreck;
 
 [_pos] call btc_deaf_fnc_earringing;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -603,6 +603,10 @@
                 <French>Type de placement des EEI:</French>
                 <Czech>Typ umístění IED:</Czech>
             </Key>
+			<Key ID="STR_BTC_HAM_PARAM_IED_BOOM">
+                <Original>Type of explosion:</Original>
+                <French>Type d'explosion:</French>
+            </Key>
             <Key ID="STR_BTC_HAM_PARAM_IED_PLACEMENT_MIDDLE">
                 <Original>Middle</Original>
                 <German>Straßenmitte</German>

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -603,7 +603,7 @@
                 <French>Type de placement des EEI:</French>
                 <Czech>Typ umístění IED:</Czech>
             </Key>
-			<Key ID="STR_BTC_HAM_PARAM_IED_BOOM">
+			<Key ID="STR_BTC_HAM_PARAM_IED_POWER">
                 <Original>Power of IED explosion:</Original>
                 <French>Type d'explosion:</French>
             </Key>

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -605,7 +605,7 @@
             </Key>
 			<Key ID="STR_BTC_HAM_PARAM_IED_POWER">
                 <Original>Power of IED explosion:</Original>
-                <French>Type d'explosion:</French>
+                <French>Puissance de l'explosion:</French>
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_IED_PLACEMENT_MIDDLE">
                 <Original>Middle</Original>

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -604,7 +604,7 @@
                 <Czech>Typ umístění IED:</Czech>
             </Key>
 			<Key ID="STR_BTC_HAM_PARAM_IED_BOOM">
-                <Original>Type of explosion:</Original>
+                <Original>Power of IED explosion:</Original>
                 <French>Type d'explosion:</French>
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_IED_PLACEMENT_MIDDLE">


### PR DESCRIPTION
- Add: Select the power of IED in mission parameters (@SOF-Ice).

**When merged this pull request will:**
- Since an update of ACE, the explosion of EEI produce several damages to the EOD. most of the time he died in few minutes.
- Thats why i propose you to choose between the standard and an an other EEI smaller. The smaller produce less damage which allows time to heal the EOD.
- https://github.com/Vdauphin/HeartsAndMinds/issues/400

**Final test:**
- [x] local
- [x] server

**Screenshots**