### PR TITLE
FIX: ACE EDEN option max rearm and refuel values not saved

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/rearmSource.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/rearmSource.sqf
@@ -36,7 +36,7 @@ private _failNotify = [
 if (_array isEqualTo []) exitWith {_failNotify call CBA_fnc_notify;};
 
 private _rearmSource = _array select 0;
-private _default_rearmCargo = _rearmSource getVariable ["btc_rearm_defaultSupply", _rearmSource call ace_rearm_fnc_getSupplyCount];
+private _default_rearmCargo = _rearmSource getVariable ["btc_EDEN_defaultSupply", _rearmSource call ace_rearm_fnc_getSupplyCount];
 
 if (_default_rearmCargo <= 0) exitWith {_failNotify call CBA_fnc_notify;};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/rearmSource.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/rearmSource.sqf
@@ -36,7 +36,7 @@ private _failNotify = [
 if (_array isEqualTo []) exitWith {_failNotify call CBA_fnc_notify;};
 
 private _rearmSource = _array select 0;
-private _default_rearmCargo = getNumber (configOf _rearmSource >> "ace_rearm_defaultSupply");
+private _default_rearmCargo = _rearmSource getVariable ["btc_rearm_defaultSupply", _rearmSource call ace_rearm_fnc_getSupplyCount];
 
 if (_default_rearmCargo <= 0) exitWith {_failNotify call CBA_fnc_notify;};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/refuelSource.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/refuelSource.sqf
@@ -36,7 +36,7 @@ private _failNotify = [
 if (_array isEqualTo []) exitWith {_failNotify call CBA_fnc_notify;};
 
 private _fuelSource = _array select 0;
-private _default_fuelCargo = getNumber (configOf _fuelSource >> "ace_refuel_fuelCargo");
+private _default_fuelCargo = _fuelSource getVariable ["btc_refuel_defaultFuelCargo", _fuelSource call ace_refuel_fnc_getFuel];
 
 if (_default_fuelCargo <= 0) exitWith {_failNotify call CBA_fnc_notify;};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/refuelSource.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/refuelSource.sqf
@@ -36,7 +36,7 @@ private _failNotify = [
 if (_array isEqualTo []) exitWith {_failNotify call CBA_fnc_notify;};
 
 private _fuelSource = _array select 0;
-private _default_fuelCargo = _fuelSource getVariable ["btc_refuel_defaultFuelCargo", _fuelSource call ace_refuel_fnc_getFuel];
+private _default_fuelCargo = _fuelSource getVariable ["btc_EDEN_defaultFuelCargo", _fuelSource call ace_refuel_fnc_getFuel];
 
 if (_default_fuelCargo <= 0) exitWith {_failNotify call CBA_fnc_notify;};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
@@ -37,8 +37,8 @@ private _vehProperties = _veh call btc_veh_fnc_propertiesGet;
 
 // Reset properties
 _vehProperties set [5, false];
-(_vehProperties select 3) set [0, _veh getVariable "btc_refuel_defaultFuelCargo"];
-(_vehProperties select 6) set [1, _veh getVariable "btc_rearm_defaultSupply"];
+(_vehProperties select 3) set [0, _veh getVariable "btc_EDEN_defaultFuelCargo"];
+(_vehProperties select 6) set [1, _veh getVariable "btc_EDEN_defaultSupply"];
 
 private _EDENinventory = _veh getVariable ["btc_EDENinventory", []];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_repair_wreck.sqf
@@ -37,8 +37,8 @@ private _vehProperties = _veh call btc_veh_fnc_propertiesGet;
 
 // Reset properties
 _vehProperties set [5, false];
-(_vehProperties select 3) set [0, getNumber (configOf _veh >> "ace_refuel_fuelCargo")];
-(_vehProperties select 6) set [1, getNumber (configOf _veh >> "ace_rearm_defaultSupply")];
+(_vehProperties select 3) set [0, _veh getVariable "btc_refuel_defaultFuelCargo"];
+(_vehProperties select 6) set [1, _veh getVariable "btc_rearm_defaultSupply"];
 
 private _EDENinventory = _veh getVariable ["btc_EDENinventory", []];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/add.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/add.sqf
@@ -31,6 +31,12 @@ if (isNil "btc_vehicles") then {
 if (isNil {_veh getVariable "btc_EDENinventory"}) then {
     _veh setVariable ["btc_EDENinventory", _veh call btc_log_fnc_inventoryGet];
 };
+if (isNil {_veh getVariable "btc_refuel_defaultFuelCargo"}) then {
+    _veh setVariable ["btc_refuel_defaultFuelCargo", _veh call ace_refuel_fnc_getFuel];
+};
+if (isNil {_veh getVariable "btc_rearm_defaultSupply"}) then {
+    _veh setVariable ["btc_rearm_defaultSupply", _veh call ace_rearm_fnc_getSupplyCount];
+};
 
 if (btc_vehicles pushBackUnique _veh isEqualTo -1) exitWith {
     if (btc_debug || btc_debug_log) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/add.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/add.sqf
@@ -34,10 +34,10 @@ if (isNil {_veh getVariable "btc_EDENinventory"}) then {
 [{ace_common_settingsInitFinished}, {
     if (isNull _this) exitwith {};
     if (isNil {_this getVariable "btc_EDEN_defaultFuelCargo"}) then {
-        _this setVariable ["btc_EDEN_defaultFuelCargo", _this call ace_refuel_fnc_getFuel];
+        _this setVariable ["btc_EDEN_defaultFuelCargo", _this call ace_refuel_fnc_getFuel, true];
     };
     if (isNil {_this getVariable "btc_EDEN_defaultSupply"}) then {
-        _this setVariable ["btc_EDEN_defaultSupply", _this call ace_rearm_fnc_getSupplyCount];
+        _this setVariable ["btc_EDEN_defaultSupply", _this call ace_rearm_fnc_getSupplyCount, true];
     };
 }, _veh] call CBA_fnc_waitUntilAndExecute;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/add.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/add.sqf
@@ -31,12 +31,17 @@ if (isNil "btc_vehicles") then {
 if (isNil {_veh getVariable "btc_EDENinventory"}) then {
     _veh setVariable ["btc_EDENinventory", _veh call btc_log_fnc_inventoryGet];
 };
-if (isNil {_veh getVariable "btc_EDEN_defaultFuelCargo"}) then {
-    _veh setVariable ["btc_EDEN_defaultFuelCargo", _veh call ace_refuel_fnc_getFuel];
-};
-if (isNil {_veh getVariable "btc_EDEN_defaultSupply"}) then {
-    _veh setVariable ["btc_EDEN_defaultSupply", _veh call ace_rearm_fnc_getSupplyCount];
-};
+["ace_settingsInitialized", {
+    _thisArgs params ["_veh"];
+    [str _veh, __FILE__, [btc_debug, btc_debug_log, true]] call btc_debug_fnc_message;
+    if (isNull _veh) exitwith {};
+    if (isNil {_veh getVariable "btc_EDEN_defaultFuelCargo"}) then {
+        _veh setVariable ["btc_EDEN_defaultFuelCargo", _veh call ace_refuel_fnc_getFuel];
+    };
+    if (isNil {_veh getVariable "btc_EDEN_defaultSupply"}) then {
+        _veh setVariable ["btc_EDEN_defaultSupply", _veh call ace_rearm_fnc_getSupplyCount];
+    };
+}, [_veh]] call CBA_fnc_addEventHandlerArgs;
 
 if (btc_vehicles pushBackUnique _veh isEqualTo -1) exitWith {
     if (btc_debug || btc_debug_log) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/add.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/add.sqf
@@ -31,11 +31,11 @@ if (isNil "btc_vehicles") then {
 if (isNil {_veh getVariable "btc_EDENinventory"}) then {
     _veh setVariable ["btc_EDENinventory", _veh call btc_log_fnc_inventoryGet];
 };
-if (isNil {_veh getVariable "btc_refuel_defaultFuelCargo"}) then {
-    _veh setVariable ["btc_refuel_defaultFuelCargo", _veh call ace_refuel_fnc_getFuel];
+if (isNil {_veh getVariable "btc_EDEN_defaultFuelCargo"}) then {
+    _veh setVariable ["btc_EDEN_defaultFuelCargo", _veh call ace_refuel_fnc_getFuel];
 };
-if (isNil {_veh getVariable "btc_rearm_defaultSupply"}) then {
-    _veh setVariable ["btc_rearm_defaultSupply", _veh call ace_rearm_fnc_getSupplyCount];
+if (isNil {_veh getVariable "btc_EDEN_defaultSupply"}) then {
+    _veh setVariable ["btc_EDEN_defaultSupply", _veh call ace_rearm_fnc_getSupplyCount];
 };
 
 if (btc_vehicles pushBackUnique _veh isEqualTo -1) exitWith {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/add.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/add.sqf
@@ -31,17 +31,15 @@ if (isNil "btc_vehicles") then {
 if (isNil {_veh getVariable "btc_EDENinventory"}) then {
     _veh setVariable ["btc_EDENinventory", _veh call btc_log_fnc_inventoryGet];
 };
-["ace_settingsInitialized", {
-    _thisArgs params ["_veh"];
-    [str _veh, __FILE__, [btc_debug, btc_debug_log, true]] call btc_debug_fnc_message;
-    if (isNull _veh) exitwith {};
-    if (isNil {_veh getVariable "btc_EDEN_defaultFuelCargo"}) then {
-        _veh setVariable ["btc_EDEN_defaultFuelCargo", _veh call ace_refuel_fnc_getFuel];
+[{ace_common_settingsInitFinished}, {
+    if (isNull _this) exitwith {};
+    if (isNil {_this getVariable "btc_EDEN_defaultFuelCargo"}) then {
+        _this setVariable ["btc_EDEN_defaultFuelCargo", _this call ace_refuel_fnc_getFuel];
     };
-    if (isNil {_veh getVariable "btc_EDEN_defaultSupply"}) then {
-        _veh setVariable ["btc_EDEN_defaultSupply", _veh call ace_rearm_fnc_getSupplyCount];
+    if (isNil {_this getVariable "btc_EDEN_defaultSupply"}) then {
+        _this setVariable ["btc_EDEN_defaultSupply", _this call ace_rearm_fnc_getSupplyCount];
     };
-}, [_veh]] call CBA_fnc_addEventHandlerArgs;
+}, _veh] call CBA_fnc_waitUntilAndExecute;
 
 if (btc_vehicles pushBackUnique _veh isEqualTo -1) exitWith {
     if (btc_debug || btc_debug_log) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/addRespawn.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/addRespawn.sqf
@@ -33,6 +33,12 @@ if (isNil "btc_veh_respawnable") then {
 if (isNil {_vehicle getVariable "btc_EDENinventory"}) then {
     _vehicle setVariable ["btc_EDENinventory", _vehicle call btc_log_fnc_inventoryGet];
 };
+if (isNil {_vehicle getVariable "btc_refuel_defaultFuelCargo"}) then {
+    _vehicle setVariable ["btc_refuel_defaultFuelCargo", _vehicle call ace_refuel_fnc_getFuel];
+};
+if (isNil {_vehicle getVariable "btc_rearm_defaultSupply"}) then {
+    _vehicle setVariable ["btc_rearm_defaultSupply", _vehicle call ace_rearm_fnc_getSupplyCount];
+};
 
 if (btc_veh_respawnable pushBackUnique _vehicle isEqualTo -1) exitWith {
     if (btc_debug || btc_debug_log) then {
@@ -48,8 +54,8 @@ private _vehProperties = _vehicle call btc_veh_fnc_propertiesGet;
 
 // Reset properties
 _vehProperties set [5, false];
-(_vehProperties select 3) set [0, getNumber (configOf _veh >> "ace_refuel_fuelCargo")];
-(_vehProperties select 6) set [1, getNumber (configOf _veh >> "ace_rearm_defaultSupply")];
+(_vehProperties select 3) set [0, _vehicle getVariable "btc_refuel_defaultFuelCargo"];
+(_vehProperties select 6) set [1, _vehicle getVariable "btc_rearm_defaultSupply"];
 
 _vehicle setVariable ["data_respawn", [_type, _pos, _dir, _time, _vector] + _vehProperties];
 _vehicle setVariable ["btc_dont_delete", true];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/addRespawn.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/addRespawn.sqf
@@ -33,11 +33,11 @@ if (isNil "btc_veh_respawnable") then {
 if (isNil {_vehicle getVariable "btc_EDENinventory"}) then {
     _vehicle setVariable ["btc_EDENinventory", _vehicle call btc_log_fnc_inventoryGet];
 };
-if (isNil {_vehicle getVariable "btc_refuel_defaultFuelCargo"}) then {
-    _vehicle setVariable ["btc_refuel_defaultFuelCargo", _vehicle call ace_refuel_fnc_getFuel];
+if (isNil {_vehicle getVariable "btc_EDEN_defaultFuelCargo"}) then {
+    _vehicle setVariable ["btc_EDEN_defaultFuelCargo", _vehicle call ace_refuel_fnc_getFuel];
 };
-if (isNil {_vehicle getVariable "btc_rearm_defaultSupply"}) then {
-    _vehicle setVariable ["btc_rearm_defaultSupply", _vehicle call ace_rearm_fnc_getSupplyCount];
+if (isNil {_vehicle getVariable "btc_EDEN_defaultSupply"}) then {
+    _vehicle setVariable ["btc_EDEN_defaultSupply", _vehicle call ace_rearm_fnc_getSupplyCount];
 };
 
 if (btc_veh_respawnable pushBackUnique _vehicle isEqualTo -1) exitWith {
@@ -54,8 +54,8 @@ private _vehProperties = _vehicle call btc_veh_fnc_propertiesGet;
 
 // Reset properties
 _vehProperties set [5, false];
-(_vehProperties select 3) set [0, _vehicle getVariable "btc_refuel_defaultFuelCargo"];
-(_vehProperties select 6) set [1, _vehicle getVariable "btc_rearm_defaultSupply"];
+(_vehProperties select 3) set [0, _vehicle getVariable "btc_EDEN_defaultFuelCargo"];
+(_vehProperties select 6) set [1, _vehicle getVariable "btc_EDEN_defaultSupply"];
 
 _vehicle setVariable ["data_respawn", [_type, _pos, _dir, _time, _vector] + _vehProperties];
 _vehicle setVariable ["btc_dont_delete", true];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/addRespawn.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/addRespawn.sqf
@@ -36,10 +36,10 @@ if (isNil {_vehicle getVariable "btc_EDENinventory"}) then {
 [{ace_common_settingsInitFinished}, {
     if (isNull _this) exitwith {};
     if (isNil {_this getVariable "btc_EDEN_defaultFuelCargo"}) then {
-        _this setVariable ["btc_EDEN_defaultFuelCargo", _this call ace_refuel_fnc_getFuel];
+        _this setVariable ["btc_EDEN_defaultFuelCargo", _this call ace_refuel_fnc_getFuel, true];
     };
     if (isNil {_this getVariable "btc_EDEN_defaultSupply"}) then {
-        _this setVariable ["btc_EDEN_defaultSupply", _this call ace_rearm_fnc_getSupplyCount];
+        _this setVariable ["btc_EDEN_defaultSupply", _this call ace_rearm_fnc_getSupplyCount, true];
     };
 }, _vehicle] call CBA_fnc_waitUntilAndExecute;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/addRespawn.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/addRespawn.sqf
@@ -33,12 +33,17 @@ if (isNil "btc_veh_respawnable") then {
 if (isNil {_vehicle getVariable "btc_EDENinventory"}) then {
     _vehicle setVariable ["btc_EDENinventory", _vehicle call btc_log_fnc_inventoryGet];
 };
-if (isNil {_vehicle getVariable "btc_EDEN_defaultFuelCargo"}) then {
-    _vehicle setVariable ["btc_EDEN_defaultFuelCargo", _vehicle call ace_refuel_fnc_getFuel];
-};
-if (isNil {_vehicle getVariable "btc_EDEN_defaultSupply"}) then {
-    _vehicle setVariable ["btc_EDEN_defaultSupply", _vehicle call ace_rearm_fnc_getSupplyCount];
-};
+["ace_settingsInitialized", {
+    _thisArgs params ["_vehicle"];
+    [str _vehicle, __FILE__, [btc_debug, btc_debug_log, true]] call btc_debug_fnc_message;
+    if (isNull _vehicle) exitwith {};
+    if (isNil {_vehicle getVariable "btc_EDEN_defaultFuelCargo"}) then {
+        _vehicle setVariable ["btc_EDEN_defaultFuelCargo", _vehicle call ace_refuel_fnc_getFuel];
+    };
+    if (isNil {_vehicle getVariable "btc_EDEN_defaultSupply"}) then {
+        _vehicle setVariable ["btc_EDEN_defaultSupply", _vehicle call ace_rearm_fnc_getSupplyCount];
+    };
+}, [_vehicle]] call CBA_fnc_addEventHandlerArgs;
 
 if (btc_veh_respawnable pushBackUnique _vehicle isEqualTo -1) exitWith {
     if (btc_debug || btc_debug_log) then {
@@ -50,14 +55,8 @@ private _type = typeOf _vehicle;
 private _pos = getPosASL _vehicle;
 private _dir = getDir _vehicle;
 private _vector = [vectorDir _vehicle, vectorUp _vehicle];
-private _vehProperties = _vehicle call btc_veh_fnc_propertiesGet;
 
-// Reset properties
-_vehProperties set [5, false];
-(_vehProperties select 3) set [0, _vehicle getVariable "btc_EDEN_defaultFuelCargo"];
-(_vehProperties select 6) set [1, _vehicle getVariable "btc_EDEN_defaultSupply"];
-
-_vehicle setVariable ["data_respawn", [_type, _pos, _dir, _time, _vector] + _vehProperties];
+_vehicle setVariable ["data_respawn", [_type, _pos, _dir, _time, _vector]];
 _vehicle setVariable ["btc_dont_delete", true];
 
 if ((isNumber (configOf _vehicle >> "ace_fastroping_enabled")) && (typeOf _vehicle isNotEqualTo "RHS_UH1Y_d")) then {_vehicle call ace_fastroping_fnc_equipFRIES};
@@ -66,6 +65,14 @@ _vehicle addMPEventHandler ["MPKilled", {
         params ["_vehicle", "_killer", "_instigator"];
 
         private _data = _vehicle getVariable ["data_respawn", []];
+        private _vehProperties = _vehicle call btc_veh_fnc_propertiesGet;
+
+        // Reset properties
+        _vehProperties set [5, false];
+        (_vehProperties select 3) set [0, _vehicle getVariable "btc_EDEN_defaultFuelCargo"];
+        (_vehProperties select 6) set [1, _vehicle getVariable "btc_EDEN_defaultSupply"];
+
+        _data append _vehProperties;
         _data pushBack (_vehicle getVariable ["btc_EDENinventory", []]);
         [btc_veh_fnc_respawn, [_vehicle, _data], _data select 3] call CBA_fnc_waitAndExecute;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/addRespawn.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/addRespawn.sqf
@@ -33,17 +33,15 @@ if (isNil "btc_veh_respawnable") then {
 if (isNil {_vehicle getVariable "btc_EDENinventory"}) then {
     _vehicle setVariable ["btc_EDENinventory", _vehicle call btc_log_fnc_inventoryGet];
 };
-["ace_settingsInitialized", {
-    _thisArgs params ["_vehicle"];
-    [str _vehicle, __FILE__, [btc_debug, btc_debug_log, true]] call btc_debug_fnc_message;
-    if (isNull _vehicle) exitwith {};
-    if (isNil {_vehicle getVariable "btc_EDEN_defaultFuelCargo"}) then {
-        _vehicle setVariable ["btc_EDEN_defaultFuelCargo", _vehicle call ace_refuel_fnc_getFuel];
+[{ace_common_settingsInitFinished}, {
+    if (isNull _this) exitwith {};
+    if (isNil {_this getVariable "btc_EDEN_defaultFuelCargo"}) then {
+        _this setVariable ["btc_EDEN_defaultFuelCargo", _this call ace_refuel_fnc_getFuel];
     };
-    if (isNil {_vehicle getVariable "btc_EDEN_defaultSupply"}) then {
-        _vehicle setVariable ["btc_EDEN_defaultSupply", _vehicle call ace_rearm_fnc_getSupplyCount];
+    if (isNil {_this getVariable "btc_EDEN_defaultSupply"}) then {
+        _this setVariable ["btc_EDEN_defaultSupply", _this call ace_rearm_fnc_getSupplyCount];
     };
-}, [_vehicle]] call CBA_fnc_addEventHandlerArgs;
+}, _vehicle] call CBA_fnc_waitUntilAndExecute;
 
 if (btc_veh_respawnable pushBackUnique _vehicle isEqualTo -1) exitWith {
     if (btc_debug || btc_debug_log) then {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesGet.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesGet.sqf
@@ -37,14 +37,14 @@ private _isRepairVehicle = _vehicle call ace_repair_fnc_isRepairVehicle;
 private _fuelSource = [
     _vehicle call ace_refuel_fnc_getFuel,
     _vehicle getVariable ["ace_refuel_hooks", []],
-    _vehicle getVariable ["btc_refuel_defaultFuelCargo", _vehicle call ace_refuel_fnc_getFuel]
+    _vehicle getVariable ["btc_EDEN_defaultFuelCargo", _vehicle call ace_refuel_fnc_getFuel]
 ];
 private _pylons = getPylonMagazines _vehicle;
 private _isContaminated = _vehicle in btc_chem_contaminated;
 private _supplyVehicle = [
     _vehicle call ace_rearm_fnc_isSource,
     _vehicle call ace_rearm_fnc_getSupplyCount,
-    _vehicle getVariable ["btc_rearm_defaultSupply", _vehicle call ace_rearm_fnc_getSupplyCount]
+    _vehicle getVariable ["btc_EDEN_defaultSupply", _vehicle call ace_rearm_fnc_getSupplyCount]
 ];
 
 [_customization, _isMedicalVehicle, _isRepairVehicle, _fuelSource, _pylons, _isContaminated, _supplyVehicle]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesGet.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesGet.sqf
@@ -36,13 +36,15 @@ private _isMedicalVehicle = _vehicle call ace_medical_treatment_fnc_isMedicalVeh
 private _isRepairVehicle = _vehicle call ace_repair_fnc_isRepairVehicle;
 private _fuelSource = [
     _vehicle call ace_refuel_fnc_getFuel,
-    _vehicle getVariable ["ace_refuel_hooks", []]
+    _vehicle getVariable ["ace_refuel_hooks", []],
+    _vehicle getVariable ["btc_refuel_defaultFuelCargo", _vehicle call ace_refuel_fnc_getFuel]
 ];
 private _pylons = getPylonMagazines _vehicle;
 private _isContaminated = _vehicle in btc_chem_contaminated;
 private _supplyVehicle = [
     _vehicle call ace_rearm_fnc_isSource,
-    _vehicle call ace_rearm_fnc_getSupplyCount
+    _vehicle call ace_rearm_fnc_getSupplyCount,
+    _vehicle getVariable ["btc_rearm_defaultSupply", _vehicle call ace_rearm_fnc_getSupplyCount]
 ];
 
 [_customization, _isMedicalVehicle, _isRepairVehicle, _fuelSource, _pylons, _isContaminated, _supplyVehicle]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesSet.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesSet.sqf
@@ -59,7 +59,7 @@ if (_fuelSource isNotEqualTo []) then {
             [_vehicle, _fuelCargo] call ace_refuel_fnc_makeSource;
         };
     };
-    _vehicle setVariable ["btc_EDEN_defaultFuelCargo", _defaultFuelCargo];
+    _vehicle setVariable ["btc_EDEN_defaultFuelCargo", _defaultFuelCargo, true];
 };
 if (_pylons isNotEqualTo []) then {
     private _pylonPaths = (configProperties [configOf _vehicle >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"]) apply {getArray (_x >> "turret")};
@@ -85,7 +85,7 @@ if (_supplyVehicle isNotEqualTo []) then {
     if (_isSupplyVehicle) then {
         [_vehicle, _currentSupply] call ace_rearm_fnc_makeSource;
     };
-    _vehicle setVariable ["btc_EDEN_defaultSupply", _defaultSupply];
+    _vehicle setVariable ["btc_EDEN_defaultSupply", _defaultSupply, true];
 };
 
 _vehicle

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesSet.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesSet.sqf
@@ -49,7 +49,8 @@ if (_isRepairVehicle && {!([_vehicle] call ace_repair_fnc_isRepairVehicle)}) the
 if (_fuelSource isNotEqualTo []) then {
     _fuelSource params [
         ["_fuelCargo", 0, [0]],
-        ["_hooks", nil, [[]]]
+        ["_hooks", nil, [[]]],
+        ["_defaultFuelCargo", -1, [0]]
     ];
     if ((!isNil "_hooks") && {_hooks isNotEqualTo (_vehicle getVariable ["ace_refuel_hooks", []])}) then {
         [_vehicle, _fuelCargo, _hooks] call ace_refuel_fnc_makeSource;
@@ -58,6 +59,7 @@ if (_fuelSource isNotEqualTo []) then {
             [_vehicle, _fuelCargo] call ace_refuel_fnc_makeSource;
         };
     };
+    _vehicle setVariable ["btc_refuel_defaultFuelCargo", _defaultFuelCargo];
 };
 if (_pylons isNotEqualTo []) then {
     private _pylonPaths = (configProperties [configOf _vehicle >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"]) apply {getArray (_x >> "turret")};
@@ -76,12 +78,14 @@ if (_isContaminated) then {
 if (_supplyVehicle isNotEqualTo []) then {
     _supplyVehicle params [
         ["_isSupplyVehicle", false, [false]],
-        ["_currentSupply", -1, [0]]
+        ["_currentSupply", -1, [0]],
+        ["_defaultSupply", -1, [0]]
     ];
 
     if (_isSupplyVehicle) then {
         [_vehicle, _currentSupply] call ace_rearm_fnc_makeSource;
     };
+    _vehicle setVariable ["btc_rearm_defaultSupply", _defaultSupply];
 };
 
 _vehicle

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesSet.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesSet.sqf
@@ -59,7 +59,7 @@ if (_fuelSource isNotEqualTo []) then {
             [_vehicle, _fuelCargo] call ace_refuel_fnc_makeSource;
         };
     };
-    _vehicle setVariable ["btc_refuel_defaultFuelCargo", _defaultFuelCargo];
+    _vehicle setVariable ["btc_EDEN_defaultFuelCargo", _defaultFuelCargo];
 };
 if (_pylons isNotEqualTo []) then {
     private _pylonPaths = (configProperties [configOf _vehicle >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"]) apply {getArray (_x >> "turret")};
@@ -85,7 +85,7 @@ if (_supplyVehicle isNotEqualTo []) then {
     if (_isSupplyVehicle) then {
         [_vehicle, _currentSupply] call ace_rearm_fnc_makeSource;
     };
-    _vehicle setVariable ["btc_rearm_defaultSupply", _defaultSupply];
+    _vehicle setVariable ["btc_EDEN_defaultSupply", _defaultSupply];
 };
 
 _vehicle

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesSet.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/veh/propertiesSet.sqf
@@ -16,7 +16,7 @@ Parameters:
     _supplyVehicle - Is supply vehicle and current supply count. [Boolean]
 
 Returns:
-	_vehicle - Vehicle. [Object]
+    _vehicle - Vehicle. [Object]
 
 Examples:
     (begin example)
@@ -50,7 +50,7 @@ if (_fuelSource isNotEqualTo []) then {
     _fuelSource params [
         ["_fuelCargo", 0, [0]],
         ["_hooks", nil, [[]]],
-        ["_defaultFuelCargo", -1, [0]]
+        ["_defaultFuelCargo", getNumber (configOf _vehicle >> "ace_refuel_fuelCargo"), [0]]
     ];
     if ((!isNil "_hooks") && {_hooks isNotEqualTo (_vehicle getVariable ["ace_refuel_hooks", []])}) then {
         [_vehicle, _fuelCargo, _hooks] call ace_refuel_fnc_makeSource;
@@ -79,7 +79,7 @@ if (_supplyVehicle isNotEqualTo []) then {
     _supplyVehicle params [
         ["_isSupplyVehicle", false, [false]],
         ["_currentSupply", -1, [0]],
-        ["_defaultSupply", -1, [0]]
+        ["_defaultSupply", getNumber (configOf _vehicle >> "ace_rearm_defaultSupply"), [0]]
     ];
 
     if (_isSupplyVehicle) then {


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Max ACE EDEN option rearm and refuel not saved (@Vdauphin).

**When merged this pull request will:**
- title
- see https://github.com/Vdauphin/HeartsAndMinds/discussions/1471

**Final test:**
- [x] local
- [x] server

**Screenshots**
