### PR TITLE
Add: Set day time and change weather

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -19,6 +19,8 @@ btc_p_db_autoRestartHour = [
 ];
 btc_p_db_autoRestartType = "btc_p_db_autoRestartType" call BIS_fnc_getParamValue;
 btc_p_slot_isShare = "btc_p_slot_isShare" call BIS_fnc_getParamValue isEqualTo 1;
+btc_p_change_time = ("btc_p_change_time" call BIS_fnc_getParamValue) isEqualTo 1;
+btc_p_change_weather = ("btc_p_change_weather" call BIS_fnc_getParamValue) isEqualTo 1;
 
 //<< Respawn options >>
 btc_p_respawn_location = "btc_p_respawn_location" call BIS_fnc_getParamValue;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -17,6 +17,18 @@ class Params {
         texts[]={"1","2","3","4","5","6","7","8","9","10","11","12"};
         default = 5;
     };
+    class btc_p_change_time { // Ace Arsenal Enable change day time
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_CHANGE_TIME_ENABLEARSENAL"]);
+        values[]={0,1};
+        texts[]={$STR_DISABLED,$STR_ENABLED};
+        default = 0;
+    };    
+    class btc_p_change_weather { // Ace Arsenal Enable change weather
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_CHANGE_WEATHER_ENABLEARSENAL"]);
+        values[]={0,1};
+        texts[]={$STR_DISABLED,$STR_ENABLED};
+        default = 0;
+    };
     class btc_p_db_title { // << Server management >>
         title = $STR_BTC_HAM_PARAM_DB_TITLE;
         values[]={0};
@@ -425,18 +437,6 @@ class Params {
         texts[]={$STR_DISABLED,$STR_ENABLED};
         default = 0;
     };
-	    class btc_p_change_time { // Ace Arsenal Enable change day time
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_CHANGE_TIME_ENABLEARSENAL"]);
-        values[]={0,1};
-        texts[]={$STR_DISABLED,$STR_ENABLED};
-        default = 0;
-    };    
-    class btc_p_change_weather { // Ace Arsenal Enable change weather
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_CHANGE_WEATHER_ENABLEARSENAL"]);
-        values[]={0,1};
-        texts[]={$STR_DISABLED,$STR_ENABLED};
-        default = 0;
-    };  
     class btc_p_main_title { // << Other options >>
         title = $STR_BTC_HAM_PARAM_OTHER_TITLE;
         values[]={0};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -425,6 +425,18 @@ class Params {
         texts[]={$STR_DISABLED,$STR_ENABLED};
         default = 0;
     };
+	    class btc_p_change_time { // Ace Arsenal Enable change day time
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_CHANGE_TIME_ENABLEARSENAL"]);
+        values[]={0,1};
+        texts[]={$STR_DISABLED,$STR_ENABLED};
+        default = 0;
+    };    
+    class btc_p_change_weather { // Ace Arsenal Enable change weather
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_CHANGE_WEATHER_ENABLEARSENAL"]);
+        values[]={0,1};
+        texts[]={$STR_DISABLED,$STR_ENABLED};
+        default = 0;
+    };  
     class btc_p_main_title { // << Other options >>
         title = $STR_BTC_HAM_PARAM_OTHER_TITLE;
         values[]={0};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -23,7 +23,7 @@ class Params {
         texts[]={$STR_DISABLED,$STR_ENABLED};
         default = 0;
     };    
-    class btc_p_change_weather { // Ace Arsenal Enable change weather
+    class btc_p_change_weather { // Enable change weather for officer on the arsenal box
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_CHANGE_WEATHER_ENABLEARSENAL"]);
         values[]={0,1};
         texts[]={$STR_DISABLED,$STR_ENABLED};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -17,7 +17,7 @@ class Params {
         texts[]={"1","2","3","4","5","6","7","8","9","10","11","12"};
         default = 5;
     };
-    class btc_p_change_time { // Ace Arsenal Enable change day time
+    class btc_p_change_time { // Enable change day time for officer on the arsenal box:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_CHANGE_TIME_ENABLEARSENAL"]);
         values[]={0,1};
         texts[]={$STR_DISABLED,$STR_ENABLED};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/changeWeather.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/common/changeWeather.sqf
@@ -1,0 +1,22 @@
+
+/* ----------------------------------------------------------------------------
+Function: btc_fnc_changeWeather
+
+Description:
+    Change weather: stop rain, stop fog and make sunny weather.
+
+Parameters:
+
+Returns:
+
+Examples:
+
+Author:
+    Ice
+
+---------------------------------------------------------------------------- */
+
+5 setRain 0;
+5 setFog 0;
+5 setOvercast 0;
+10 setRainbow 1;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -30,6 +30,7 @@ if (isServer) then {
     btc_fnc_typeOf = compileScript ["core\fnc\common\typeOf.sqf"];
     btc_fnc_roof = compileScript ["core\fnc\common\roof.sqf"];
     btc_fnc_moveOut = compileScript ["core\fnc\common\moveOut.sqf"];
+	btc_fnc_changeWeather = compileScript ["core\fnc\common\changeWeather.sqf"];
 
     //CHEM
     btc_chem_fnc_checkLoop = compileScript ["core\fnc\chem\checkLoop.sqf"];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/compile.sqf
@@ -30,7 +30,7 @@ if (isServer) then {
     btc_fnc_typeOf = compileScript ["core\fnc\common\typeOf.sqf"];
     btc_fnc_roof = compileScript ["core\fnc\common\roof.sqf"];
     btc_fnc_moveOut = compileScript ["core\fnc\common\moveOut.sqf"];
-	btc_fnc_changeWeather = compileScript ["core\fnc\common\changeWeather.sqf"];
+    btc_fnc_changeWeather = compileScript ["core\fnc\common\changeWeather.sqf"];
 
     //CHEM
     btc_chem_fnc_checkLoop = compileScript ["core\fnc\chem\checkLoop.sqf"];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -249,3 +249,19 @@ if (btc_p_flag > 1) then {
     }, {getForcedFlagTexture _target isNotEqualTo ""}] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions", "ACE_Equipment"], _action] call ace_interact_menu_fnc_addActionToObject;
 };
+
+//Change day time and weather
+_action = ["env_menu", localize "STR_BTC_HAM_ACTION_ENV_MENU", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {}, {player getVariable ["side_mission", false] && (btc_p_change_time || btc_p_change_weather)}] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+_action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {((6 - dayTime + 24) % 24) remoteExecCall ["skipTime", 0]}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
+_action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {((22 - dayTime + 24) % 24) remoteExecCall ["skipTime"], 0}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
+_action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", { 
+  5 setRain 0;
+  5 setFog 0;
+  5 setOvercast 0;
+  10 setRainbow 1;
+  forceWeatherChange;
+}, {btc_p_change_weather && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+[btc_gear_object, 0, ["ACE_MainActions","env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -253,9 +253,9 @@ if (btc_p_flag > 1) then {
 //Change day time and weather
 _action = ["env_menu", localize "str_a3_credits_environment", "", {}, {player getVariable ["side_mission", false] && (btc_p_change_time || btc_p_change_weather)}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "", {((6 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2]}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\Watch_ca.paa", {((6 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2]}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "", {((22 - dayTime + 24) % 24) remoteExecCall ["skipTime"], 2}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\Watch_ca.paa", {((22 - dayTime + 24) % 24) remoteExecCall ["skipTime"], 2}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "", {[] remoteExecCall ["btc_fnc_changeWeather", 2]}, {btc_p_change_weather && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "a3\3den\data\attributes\slidertimeday\sun_ca.paa", {[] remoteExecCall ["btc_fnc_changeWeather", 2]}, {btc_p_change_weather && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions","env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -251,11 +251,11 @@ if (btc_p_flag > 1) then {
 };
 
 //Change day time and weather
-_action = ["env_menu", localize "str_a3_credits_environment", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {}, {player getVariable ["side_mission", false] && (btc_p_change_time || btc_p_change_weather)}] call ace_interact_menu_fnc_createAction;
+_action = ["env_menu", localize "str_a3_credits_environment", "", {}, {player getVariable ["side_mission", false] && (btc_p_change_time || btc_p_change_weather)}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {((6 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2]}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "", {((6 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2]}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {((22 - dayTime + 24) % 24) remoteExecCall ["skipTime"], 2}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "", {((22 - dayTime + 24) % 24) remoteExecCall ["skipTime"], 2}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {[] remoteExecCall ["btc_fnc_changeWeather", 2]}, {btc_p_change_weather && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "", {[] remoteExecCall ["btc_fnc_changeWeather", 2]}, {btc_p_change_weather && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions","env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -258,10 +258,10 @@ _action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "\A3\ui_f\data\igui
 _action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {((22 - dayTime + 24) % 24) remoteExecCall ["skipTime"], 0}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
 _action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", { 
-  5 setRain 0;
-  5 setFog 0;
-  5 setOvercast 0;
-  10 setRainbow 1;
-  forceWeatherChange;
+    5 setRain 0;
+    5 setFog 0;
+    5 setOvercast 0;
+    10 setRainbow 1;
+    forceWeatherChange;
 }, {btc_p_change_weather && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions","env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -251,17 +251,11 @@ if (btc_p_flag > 1) then {
 };
 
 //Change day time and weather
-_action = ["env_menu", localize "STR_BTC_HAM_ACTION_ENV_MENU", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {}, {player getVariable ["side_mission", false] && (btc_p_change_time || btc_p_change_weather)}] call ace_interact_menu_fnc_createAction;
+_action = ["env_menu", localize "str_a3_credits_environment", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {}, {player getVariable ["side_mission", false] && (btc_p_change_time || btc_p_change_weather)}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {((6 - dayTime + 24) % 24) remoteExecCall ["skipTime", 0]}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {((6 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2]}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {((22 - dayTime + 24) % 24) remoteExecCall ["skipTime"], 0}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {((22 - dayTime + 24) % 24) remoteExecCall ["skipTime"], 2}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", { 
-    5 setRain 0;
-    5 setFog 0;
-    5 setOvercast 0;
-    10 setRainbow 1;
-    forceWeatherChange;
-}, {btc_p_change_weather && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "\A3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa", {[] remoteExecCall ["btc_fnc_changeWeather", 2]}, {btc_p_change_weather && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions","env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -258,7 +258,11 @@ _action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "\A3\Ui_f\data\GUI\
     ((_hour + 1 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2];
 }, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\Watch_ca.paa", {((22 - dayTime + 24) % 24) remoteExecCall ["skipTime"], 2}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\Watch_ca.paa", {
+    private _hour = date call BIS_fnc_sunriseSunsetTime select 1;
+    ((_hour + 1 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2];
+}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
 _action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "a3\3den\data\attributes\slidertimeday\sun_ca.paa", {[] remoteExecCall ["btc_fnc_changeWeather", 2]}, {btc_p_change_weather && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions","env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -253,7 +253,10 @@ if (btc_p_flag > 1) then {
 //Change day time and weather
 _action = ["env_menu", localize "str_a3_credits_environment", "", {}, {player getVariable ["side_mission", false] && (btc_p_change_time || btc_p_change_weather)}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\Watch_ca.paa", {((6 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2]}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\Watch_ca.paa", {
+    private _hour = date call BIS_fnc_sunriseSunsetTime select 0;
+    ((_hour + 1 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2];
+}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
 _action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\Watch_ca.paa", {((22 - dayTime + 24) % 24) remoteExecCall ["skipTime"], 2}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -2170,10 +2170,6 @@
             </Key>
         </Container>
         <Container name="Action(ACE): Change day time and weather">
-            <Key ID="STR_BTC_HAM_ACTION_ENV_MENU">
-                <Original>Environment</Original>
-                <French>Environnement</French>
-            </Key>
             <Key ID="STR_BTC_HAM_ACTION_SET_DAY">
                 <Original>Set day time</Original>
                 <French>Mettre le jour</French>
@@ -2187,12 +2183,12 @@
                 <French>Changer la météo</French>
             </Key>
             <Key ID="STR_BTC_HAM_CHANGE_TIME_ENABLEARSENAL">
-                <Original>Enable change day time for officer:</Original>
-                <French>Autoriser le changement d'heure pour les officiers:</French>
+                <Original>Enable change day time for officer on the arsenal box:</Original>
+                <French>Autoriser le changement d'heure pour les officiers sur la caisse arsenal:</French>
             </Key>
             <Key ID="STR_BTC_HAM_CHANGE_WEATHER_ENABLEARSENAL">
-                <Original>Enable change weather for officer:</Original>
-                <French>Autoriser le changement de météo pour les officiers:</French>
+                <Original>Enable change weather for officer on the arsenal box:</Original>
+                <French>Autoriser le changement de météo pour les officiers sur la caisse arsenal:</French>
             </Key>
         </Container>
     </Package>

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -2169,6 +2169,32 @@
                 <Czech>Rozbijte zámek dveří</Czech>
             </Key>
         </Container>
+        <Container name="Action(ACE): Change day time and weather">
+            <Key ID="STR_BTC_HAM_ACTION_ENV_MENU">
+                <Original>Environment</Original>
+                <French>Environnement</French>
+            </Key>
+            <Key ID="STR_BTC_HAM_ACTION_SET_DAY">
+                <Original>Set day time</Original>
+                <French>Mettre le jour</French>
+            </Key>
+            <Key ID="STR_BTC_HAM_ACTION_SET_NIGHT">
+                <Original>Set night time</Original>
+                <French>Mettre la nuit</French>
+            </Key>
+            <Key ID="STR_BTC_HAM_ACTION_CHANGE_WEATHER">
+                <Original>Change weather</Original>
+                <French>Changer la météo</French>
+            </Key>
+            <Key ID="STR_BTC_HAM_CHANGE_TIME_ENABLEARSENAL">
+                <Original>Enable change day time for officer:</Original>
+                <French>Autoriser le changement d'heure pour les officiers:</French>
+            </Key>
+            <Key ID="STR_BTC_HAM_CHANGE_WEATHER_ENABLEARSENAL">
+                <Original>Enable change weather for officer:</Original>
+                <French>Autoriser le changement de météo pour les officiers:</French>
+            </Key>
+        </Container>
     </Package>
     <Package name="Conversations">
         <Container name="Conversations: Info">


### PR DESCRIPTION
<!-- Use English only. -->

- Add: Possibility to create ACE interaction to change time and weather /!\ **_only for officers_** /!\ (@SOF-Ice, @TomDraal).

**When merged this pull request will:**
- Add Ace interaction on btc_gear_object
- Possibility to change time (day or night) and weather in game without using Zeus modules
- Add new containers and keys in stringtable for those script with french traduction
- https://github.com/Vdauphin/HeartsAndMinds/issues/400

**Final test:**
- [x] local
- [x] server

**Screenshot**

![20230114030039_1](https://user-images.githubusercontent.com/116744742/212445698-1fc91df3-1fbc-45eb-b1a3-bce548b7f8d4.jpg)
