### PR TITLE
FIX: Don't propagate chem on object declare has string

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/propagate.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/propagate.sqf
@@ -22,9 +22,11 @@ Author:
 ---------------------------------------------------------------------------- */
 
 params [
-    ["_item", objNull, [objNull]],
+    ["_item", objNull, [objNull, ""]],
     ["_vehicle", objNull, [objNull]]
 ];
+
+if (_item isEqualType "") exitWith {_this};
 
 if (_item in btc_chem_contaminated) then {
     if ((btc_chem_contaminated pushBackUnique _vehicle) > -1) then {


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Don't propagate chem on object declare has string (@Vdauphin).

**When merged this pull request will:**
- title

**Final test:**
- [x] local
- [x] server

**Screenshots**
