### PR TITLE
FIX: Dynamic Groups Init creating players without groups

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_player.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_player.sqf
@@ -15,7 +15,7 @@ btc_intro_done = [] spawn btc_respawn_fnc_intro;
 
     btc_respawn_marker setMarkerPosLocal player;
     player addRating 9999;
-    ["InitializePlayer", [player]] call BIS_fnc_dynamicGroups;
+    ["InitializePlayer", [player, true]] call BIS_fnc_dynamicGroups;
 
     [player] call btc_eh_fnc_player;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/init_server.sqf
@@ -1,6 +1,6 @@
 [] call compileScript ["core\fnc\city\init.sqf"];
 
-["Initialize"] call BIS_fnc_dynamicGroups;
+["Initialize", [true]] call BIS_fnc_dynamicGroups;
 setTimeMultiplier btc_p_acctime;
 
 ["btc_m", -1, objNull, "", false, false] call btc_task_fnc_create;


### PR DESCRIPTION
- FIX: Dynamic Groups Init creating players without groups (@mrschick).

**When merged this pull request will:**
- Change the Dynamic Groups Init on server and players to register pre-existing groups, as per the [documentation](https://community.bistudio.com/wiki/Arma_3:_Dynamic_Groups#Installation).
Our community uses a modified mission file in which the playable slots are already organized into fireteams and leadership elements, with pre-made loadouts.
Sometimes entering a slot would cause the group to not be registered and the player be somewhat desynced on the server, not being able to join a group or creating his own group, leading to related issues like not being able to open the UAV terminal or control Drones.

**Final test:**
- [x] local
- [x] server

**Screenshots**
None yet.