### PR TITLE
Add: Save Slot Parameter

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -19,6 +19,7 @@ btc_p_db_autoRestartHour = [
 ];
 btc_p_db_autoRestartType = "btc_p_db_autoRestartType" call BIS_fnc_getParamValue;
 btc_p_slot_isShare = "btc_p_slot_isShare" call BIS_fnc_getParamValue isEqualTo 1;
+btc_p_slot_isSaved = "btc_p_slot_isSaved" call BIS_fnc_getParamValue isEqualTo 1;
 btc_p_change_time = ("btc_p_change_time" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_change_weather = ("btc_p_change_weather" call BIS_fnc_getParamValue) isEqualTo 1;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -137,6 +137,12 @@ class Params {
         texts[]={$STR_DISABLED, $STR_ENABLED};
         default = 1;
     };
+    class btc_p_slot_isSaved { // Slot info is saved between disconnects
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SLOT_ISSAVED"]);
+        values[]={0,1};
+        texts[]={$STR_DISABLED, $STR_ENABLED};
+        default = 0;
+    };
     class btc_p_type_title { // << Faction options >>
         title = $STR_BTC_HAM_PARAM_FAC_TITLE;
         values[]={0};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/slot/deserializeState.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/slot/deserializeState.sqf
@@ -39,6 +39,8 @@ Author:
         ["_field_rations", [], [[]]]
     ];
 
+    if (!btc_p_slot_isSaved) exitWith {};
+
     if (
         player distance ASLToAGL _previousPos > 50 || // Don't set loadout when near main base
         btc_p_autoloadout isEqualTo 0

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/slot/serializeState.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/slot/serializeState.sqf
@@ -25,7 +25,8 @@ params [
 ];
 
 if (
-    isNil {_unit getVariable "btc_slot_key"}
+    isNil {_unit getVariable "btc_slot_key"} || 
+    {!btc_p_slot_isSaved}
 ) exitWith {};
 
 private _loadout = [_unit] call CBA_fnc_getLoadout;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -802,6 +802,9 @@
                 <French>Arsenal ACE disponible après avoir était tué:</French>
                 <Czech>ACE Arsenal dostupný při respawnu po zabití:</Czech>
             </Key>
+            <Key ID="STR_BTC_HAM_PARAM_SLOT_ISSAVED">
+                <Original>Each slot's position and loadout is saved between connections</Original>
+            </Key>
             <Key ID="STR_BTC_HAM_PARAM_SLOT_ISSHARE">
                 <Original>Each slot is share between players</Original>
                 <French>Les slots sont partagés entre tous les joueurs</French>


### PR DESCRIPTION
- Add: Mission Parameter to toggle loadout/position saving between connections (@mrschick).

**When merged this pull request will:**
- Add a mission parameter that allows selecting whether a player slot's current position and loadout should persist between connections.

**Final test:**
- [x] local
- [x] server

**Screenshots**
None applicable.