### PR TITLE
Add: Compatibility with Restrict Markers

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -274,7 +274,7 @@ private _markers_properties = +(profileNamespace getVariable [format ["btc_hm_%1
         ["_markerChannel", 0, [0]]
     ];
 
-    private _marker = createMarker [format ["_USER_DEFINED #0/%1/%2", _forEachindex, _markerChannel], _markerPos, _markerChannel];
+    private _marker = createMarker [format ["_USER_DEFINED #0/%1/%2 btc_hm", _forEachindex, _markerChannel], _markerPos, _markerChannel];
     _marker setMarkerText _markerText;
     _marker setMarkerColor _markerColor;
     _marker setMarkerType _markerType;


### PR DESCRIPTION
<!-- Use English only. -->

- Add: Compatibility with Restrict Markers (@mrschick).

**When merged this pull request will:**
- Append a custom suffix to the markers loaded from the DB at mission start, making the system compatible with [Restrict Markers - Bagigi Fork](https://steamcommunity.com/sharedfiles/filedetails/?id=3245243732).\
Without this change, markers loaded from the DB would immediately be processed (turned into local copies) by Restrict Markers and not be available anymore to JIP clients.\
With the change, loaded markers will remain global until modified or deleted.

**Final test:**
- [x] local
- [x] server