### PR TITLE
FIX: Minor Improvements

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/hd.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/hd.sqf
@@ -63,7 +63,7 @@ if (
 
     private _marker = createMarker [format ["btc_cache_%1", btc_cache_n], btc_cache_pos];
     _marker setMarkerType "hd_destroy";
-    [_marker, "STR_BTC_HAM_O_EH_HDCACHE_MRK", btc_cache_n] remoteExecCall ["btc_fnc_set_markerTextLocal", [0, -2] select isDedicated, _marker]; //Cached %1 destroyed
+    [_marker, "STR_BTC_HAM_O_EH_HDCACHE_MRK", btc_cache_n] remoteExecCall ["btc_fnc_set_markerTextLocal", [0, -2] select isDedicated, _marker]; //Cache %1 destroyed
     _marker setMarkerSize [1, 1];
     _marker setMarkerColor "ColorRed";
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -256,13 +256,13 @@ _action = ["env_menu", localize "str_a3_credits_environment", "", {}, {player ge
 _action = ["set_day", localize "STR_BTC_HAM_ACTION_SET_DAY", "\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\Watch_ca.paa", {
     private _hour = date call BIS_fnc_sunriseSunsetTime select 0;
     ((_hour + 1 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2];
-}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+}, {btc_p_change_time}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
 _action = ["set_night", localize "STR_BTC_HAM_ACTION_SET_NIGHT", "\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\Watch_ca.paa", {
     private _hour = date call BIS_fnc_sunriseSunsetTime select 1;
     ((_hour + 1 - dayTime + 24) % 24) remoteExecCall ["skipTime", 2];
-}, {btc_p_change_time && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+}, {btc_p_change_time}] call ace_interact_menu_fnc_createAction;
 
 [btc_gear_object, 0, ["ACE_MainActions", "env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;
-_action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "a3\3den\data\attributes\slidertimeday\sun_ca.paa", {[] remoteExecCall ["btc_fnc_changeWeather", 2]}, {btc_p_change_weather && player getVariable ["side_mission", false]}] call ace_interact_menu_fnc_createAction;
+_action = ["set_weather", localize "STR_BTC_HAM_ACTION_CHANGE_WEATHER", "a3\3den\data\attributes\slidertimeday\sun_ca.paa", {[] remoteExecCall ["btc_fnc_changeWeather", 2]}, {btc_p_change_weather}] call ace_interact_menu_fnc_createAction;
 [btc_gear_object, 0, ["ACE_MainActions","env_menu"], _action] call ace_interact_menu_fnc_addActionToObject;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -2898,7 +2898,7 @@
                 <Czech>Úkryt %1 zničen</Czech>
             </Key>
             <Key ID="STR_BTC_HAM_O_EH_HDCACHE_MRK">
-                <Original>Cached %1 destroyed</Original>
+                <Original>Cache %1 destroyed</Original>
                 <Spanish>Cache %1 destruído</Spanish>
                 <German>Waffenlager %1 wurde zerstört</German>
                 <Portuguese>Depósito %1 destruído</Portuguese>


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: "Cached" Typo (@mrschick).
- FIX: Refactor Time/Weather Interaction Conditions (@mrschick).

**When merged this pull request will:**
- Fix typo: [Ammo] "Cached", used in "ammo cache destroyed" markers.
- Refactor change time/weather interaction conditions on the Arsenal Box. If the parent `env_menu` condition is not met, the children won't be shown, so they don't need to check again for `player getVariable ["side_mission", false]`.

**Final test:**
- [x] local
- [x] server

**Screenshots**
