### PR TITLE
Add: Side Mission Improvements

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/capture_officer.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/capture_officer.sqf
@@ -140,7 +140,7 @@ for "_i" from 1 to _convoyLength do {
     _trigger setVariable ["captive", _captive];
     _trigger setTriggerArea [15, 15, 0, false];
     _trigger setTriggerActivation [str btc_player_side, "PRESENT", true];
-    _trigger setTriggerStatements ["this", format ["_captive = thisTrigger getVariable 'captive'; deleteVehicle thisTrigger; doStop _captive; [_captive, true] call ace_captives_fnc_setSurrendered; ['%1', 'SUCCEEDED'] call BIS_fnc_taskSetState; [['%2', '%4'], 29, _captive] call btc_task_fnc_create; [['%3', '%4'], 21, btc_create_object_point, typeOf btc_create_object_point] call btc_task_fnc_create;", _surrender_taskID, _handcuff_taskID, _back_taskID, _taskID], ""];
+    _trigger setTriggerStatements ["this", format ["_captive = thisTrigger getVariable 'captive'; deleteVehicle thisTrigger; moveOut _captive; doStop _captive; [_captive, true] call ace_captives_fnc_setSurrendered; ['%1', 'SUCCEEDED'] call BIS_fnc_taskSetState; [['%2', '%4'], 29, _captive] call btc_task_fnc_create; [['%3', '%4'], 21, btc_create_object_point, typeOf btc_create_object_point] call btc_task_fnc_create;", _surrender_taskID, _handcuff_taskID, _back_taskID, _taskID], ""];
     _trigger attachTo [_captive, [0, 0, 0]];
 
     ["ace_captiveStatusChanged", {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
@@ -60,9 +60,26 @@ private _civType = selectRandom btc_civ_type_units;
 private _captive = _group_civ createUnit [_civType, _pos, [], 0, "CAN_COLLIDE"];
 waitUntil {local _captive};
 [_captive, true] call ACE_captives_fnc_setHandcuffed;
+private _i = 0;
+while {insideBuilding _captive < 0.1 && _i < count _buildingPos} do {
+    _pos = _buildingPos select _i;
+    _captive setPosATL _pos;
+    _i = _i + 1;
+};
+
+//// Randomize Task position, but keep target house be within 50m radius of the task
+private _taskPosition = position _house;
+_taskPosition = _taskPosition vectorAdd [(random 35) - 35, (random 35) - 35]; // 35 = 50 * sin(45)
+//// Visualize area of uncertainty with marker
+private _area = createMarker [format ["sm_%1", _taskPosition], _taskPosition];
+_area setMarkerShape "ELLIPSE";
+_area setMarkerBrush "SolidBorder";
+_area setMarkerSize [50, 50];
+_area setMarkerAlpha 0.3;
+_area setmarkercolor "colorBlue";
 
 //// Data side mission
-[_taskID, 15, _captive, [_city getVariable "name", _civType]] call btc_task_fnc_create;
+[_taskID, 15, _taskPosition, [_city getVariable "name", _civType]] call btc_task_fnc_create;
 
 private _group = [];
 {
@@ -103,11 +120,11 @@ _group_civ setVariable ["no_cache", false];
 } forEach _group;
 
 if (_taskID call BIS_fnc_taskState isEqualTo "CANCELED") exitWith {
-    [[], _group + [_group_civ, _trigger, _mine]] call btc_fnc_delete;
+    [[_area], _group + [_group_civ, _trigger, _mine]] call btc_fnc_delete;
 };
 if !(alive _captive) exitWith {
     [_taskID, "FAILED"] call BIS_fnc_taskSetState;
-    [[], _group + [_group_civ, _trigger, _mine]] call btc_fnc_delete;
+    [[_area], _group + [_group_civ, _trigger, _mine]] call btc_fnc_delete;
 };
 
 40 call btc_rep_fnc_change;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
@@ -67,19 +67,8 @@ while {insideBuilding _captive < 0.1 && _i < count _buildingPos} do {
     _i = _i + 1;
 };
 
-//// Randomize Task position, but keep target house be within 50m radius of the task
-private _taskPosition = position _house;
-_taskPosition = _taskPosition vectorAdd [(random 35) - 35, (random 35) - 35]; // 35 = 50 * sin(45)
-//// Visualize area of uncertainty with marker
-private _area = createMarker [format ["sm_%1", _taskPosition], _taskPosition];
-_area setMarkerShape "ELLIPSE";
-_area setMarkerBrush "SolidBorder";
-_area setMarkerSize [50, 50];
-_area setMarkerAlpha 0.3;
-_area setmarkercolor "colorBlue";
-
 //// Data side mission
-[_taskID, 15, _taskPosition, [_city getVariable "name", _civType]] call btc_task_fnc_create;
+[_taskID, 15, _captive, [_city getVariable "name", _civType]] call btc_task_fnc_create;
 
 private _group = [];
 {
@@ -120,15 +109,13 @@ _group_civ setVariable ["no_cache", false];
 } forEach _group;
 
 if (_taskID call BIS_fnc_taskState isEqualTo "CANCELED") exitWith {
-    [[_area], _group + [_group_civ, _trigger, _mine]] call btc_fnc_delete;
+    [[], _group + [_group_civ, _trigger, _mine]] call btc_fnc_delete;
 };
 if !(alive _captive) exitWith {
     [_taskID, "FAILED"] call BIS_fnc_taskSetState;
-    [[_area], _group + [_group_civ, _trigger, _mine]] call btc_fnc_delete;
+    [[], _group + [_group_civ, _trigger, _mine]] call btc_fnc_delete;
 };
 
 40 call btc_rep_fnc_change;
 
 [_taskID, "SUCCEEDED"] call BIS_fnc_taskSetState;
-
-deleteMarker _area;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/hostage.sqf
@@ -130,3 +130,5 @@ if !(alive _captive) exitWith {
 40 call btc_rep_fnc_change;
 
 [_taskID, "SUCCEEDED"] call BIS_fnc_taskSetState;
+
+deleteMarker _area;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/kill.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/kill.sqf
@@ -66,22 +66,11 @@ while {insideBuilding _officer < 0.1 && _i < count _buildingPos} do {
     _i = _i + 1;
 };
 
-//// Randomize Task position, but keep target house be within 50m radius of the task
-private _taskPosition = position _house;
-_taskPosition = _taskPosition vectorAdd [(random 35) - 35, (random 35) - 35]; // 35 = 50 * sin(45)
-//// Visualize area of uncertainty with marker
-private _area = createMarker [format ["sm_%1", _taskPosition], _taskPosition];
-_area setMarkerShape "ELLIPSE";
-_area setMarkerBrush "SolidBorder";
-_area setMarkerSize [50, 50];
-_area setMarkerAlpha 0.3;
-_area setmarkercolor "colorBlue";
-
 //// Data side mission
 private _officerName = name _officer;
 [_taskID, 25, objNull, [_officerName, _city getVariable "name"]] call btc_task_fnc_create;
 private _kill_taskID = _taskID + "ki";
-[[_kill_taskID, _taskID], 26, _taskPosition, [_officerName, _city getVariable "name", _officerType]] call btc_task_fnc_create;
+[[_kill_taskID, _taskID], 26, _officer, [_officerName, _city getVariable "name", _officerType]] call btc_task_fnc_create;
 
 private _ehDeleted = [_officer, "Deleted", {
     params [
@@ -116,12 +105,12 @@ waitUntil {sleep 5;
     !alive _officer
 };
 if (_taskID call BIS_fnc_taskState isEqualTo "CANCELED") exitWith {
-    [[_area], _toDelete] call btc_fnc_delete;
+    [[], _toDelete] call btc_fnc_delete;
 };
 
 [_kill_taskID, "SUCCEEDED"] call BIS_fnc_taskSetState;
 private _dogTag_taskID = _taskID + "dt";
-[[_dogTag_taskID, _taskID], 27, _taskPosition, _officerName] call btc_task_fnc_create;
+[[_dogTag_taskID, _taskID], 27, _officer, _officerName] call btc_task_fnc_create;
 private _officer_dogtagData = [_officer] call ace_dogtags_fnc_getDogtagData;
 private _globalVariableName = format ["btc_%1", _dogTag_taskID];
 
@@ -177,7 +166,7 @@ _group_officer setVariable ["no_cache", false];
     _x setVariable ["no_cache", false];
 } forEach _group;
 
-[[_area], _toDelete] call btc_fnc_delete;
+[[], _toDelete] call btc_fnc_delete;
 removeMissionEventHandler ["HandleDisconnect", _IDEH_HandleDisconnect];
 if ((_taskID call BIS_fnc_taskState) in ["CANCELED", "FAILED"]) exitWith {[_taskID, _taskID call BIS_fnc_taskState] call btc_task_fnc_setState};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
@@ -78,6 +78,7 @@ private _back_taskID = _taskID + "bk";
 private _units = [];
 private _triggers = [];
 {
+    _x setVariable ["kjw_imposters_core_ignore", true, true]; // Prevent KJW Imposters from resetting captive state
     _x setCaptive true;
     removeAllWeapons _x;
     _x setBehaviour "CARELESS";

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
@@ -65,7 +65,7 @@ private _bank = if (random 1 > 0.5) then {
 [_heli, _pitch, _bank] call BIS_fnc_setPitchBank;
 private _fx = createVehicle ["test_EmptyObjectForSmoke", _pos, [], 0, "CAN_COLLIDE"];
 
-private _group = createGroup btc_player_side;
+private _group = createGroup civilian;
 _group setVariable ["no_cache", true];
 private _crew = getText (configfile >> "CfgVehicles" >> _heli_type >> "crew");
 _crew createUnit [_pos, _group];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
@@ -65,7 +65,7 @@ private _bank = if (random 1 > 0.5) then {
 [_heli, _pitch, _bank] call BIS_fnc_setPitchBank;
 private _fx = createVehicle ["test_EmptyObjectForSmoke", _pos, [], 0, "CAN_COLLIDE"];
 
-private _group = createGroup civilian;
+private _group = createGroup btc_player_side;
 _group setVariable ["no_cache", true];
 private _crew = getText (configfile >> "CfgVehicles" >> _heli_type >> "crew");
 _crew createUnit [_pos, _group];


### PR DESCRIPTION
<!-- Use English only. -->

- Add: Side Mission Improvements (@mrschick).

**When merged this pull request will:**
- In the "Capture Officer in Convoy" Mission, fix the Officer not disembarking his vehicle once surrendered.\
Previously, if the officer's vehicle was not disabled (leading to him disembarking) before "surrendering" him, it would become almost impossible to get him out of the vehicle safely.\
Now, he will disembark by himself, regardless of vehicle health, before surrendering.
- In the "Rescue Heli Pilot" Mission, fix the Pilot being "found" immediately after mission creation.\
This was being caused by the pilot activating his own "found" trigger, which looks for units of the player side <20m from the pilot, being turned non-captive and then often being killed by nearby enemy units, before players had a chance to clear the area first.\
~~I fixed this by changing the "unfound" pilot's side to civilian, as he is later switched to the player side anyway when joining the group of the players who found him.~~ TBD
- In the Assassination and Hostage Rescue Missions:
  - ~~Do not place the task on the exact position of the unit to kill/rescue, instead place it nearby, so that the house in which the officer/hostage is located is within a 50m "Area of Uncertainty", displayed around the task (re-uses supply mission "area" marker, see images below).~~
  - After placing the Officer/Hostage on a random position in the building, if that position is "outside" (often porch or roof), cycle through available positions again for one that is "inside" to place the Officer/Hostage in. Then place guarding units in all other positions.
  - Do not use small buildings with less than 4 positions for Assassination missions.

**Final test:**
- [x] local
- [x] server

**Screenshots**

"Area of Uncertainty" for Hostage/Assassination Missions:
![new-task-aou](https://github.com/user-attachments/assets/4f0adc93-0d3d-47a8-a17d-6f62c63bbe32)

