### PR TITLE
FIX: Suicide/Drone bomber compatibility with KJW_Imposters

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/droneLoop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/droneLoop.sqf
@@ -29,7 +29,7 @@ Author:
     private _group = group _driver_drone;
     if (alive _driver_drone && !isNull _driver_drone) then {
         private _array = _driver_drone nearEntities [btc_player_type, 200];
-        _array = _array select {side group _x isEqualTo btc_player_side};
+        _array = _array select {side group _x isEqualTo btc_player_side && {!captive _x}};
         if (_array isEqualTo []) then {
             if (waypoints _group isEqualTo []) then {
                 [_group, _rpos, _area, 4] call CBA_fnc_taskPatrol;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suiciderLoop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suiciderLoop.sqf
@@ -25,7 +25,7 @@ Author:
 
     if (alive _suicider && !isNull _suicider) then {
         private _array = _suicider nearEntities [btc_player_type, 25];
-        _array = _array select {side group _x isEqualTo btc_player_side};
+        _array = _array select {side group _x isEqualTo btc_player_side && {!captive _x}};
         if (_array isNotEqualTo []) exitWith {
             _suicider call btc_ied_fnc_suicider_active;
         };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_active.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_active.sqf
@@ -40,7 +40,7 @@ _trigger setVariable ["suicider", _suicider];
 _trigger attachTo [_suicider, [0, 0, 0]];
 
 private _array = getPos _suicider nearEntities [btc_player_type, 30];
-_array = _array select {side group _x isEqualTo btc_player_side};
+_array = _array select {side group _x isEqualTo btc_player_side && {!captive _x}};
 
 if (_array isEqualTo []) exitWith {};
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_activeLoop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/ied/suicider_activeLoop.sqf
@@ -26,7 +26,7 @@ Author:
 
     if (alive _suicider) then {
         private _array = _suicider nearEntities [btc_player_type, 30];
-        _array = _array select {side group _x isEqualTo btc_player_side};
+        _array = _array select {side group _x isEqualTo btc_player_side && {!captive _x}};
         if (_array isNotEqualTo []) then {
             _suicider doMove (position (_array select 0));
         };


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Suicide/Drone bomber compatibility with KJW_Imposters (@mrschick).

**When merged this pull request will:**
- Make Suicide/Drone Bombers ignore "captive" units of the player side in their search and activation conditions/loops, this will make that system compatible with [KJW_Imposters](https://steamcommunity.com/sharedfiles/filedetails/?id=2917554904), preventing covert units from being targeted.

**Final test:**
- [x] local
- [x] server
