### PR TITLE
FIX: Use ACE Progressbar for Interactions

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/door/break.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/door/break.sqf
@@ -24,10 +24,8 @@ if (_door isEqualTo "") exitWith {
     (localize "STR_BTC_HAM_O_DOOR_NO") call CBA_fnc_notify;
 };
 
-[localize "STR_BTC_HAM_O_DOOR_BREAKING", btc_door_breaking_time, {
-    [player, objNull, ["isnotinside"]] call ace_common_fnc_canInteractWith
-}, {
+[btc_door_breaking_time, [_house, _door, player, 0.2], {
     params ["_args"];
     playSound3D ["\z\ace\addons\logistics_wirecutter\sound\wirecut.ogg", player];
     _args call btc_door_fnc_broke;
-}, {}, [_house, _door, player, 0.2]] call CBA_fnc_progressBar;
+}, {}, localize "STR_BTC_HAM_O_DOOR_BREAKING", {true}, ["isNotInside"]] call ace_common_fnc_progressBar;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/info/search_for_intel.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/info/search_for_intel.sqf
@@ -41,4 +41,4 @@ private _condition = {
     (_target distance _player < _radius) && {[_player, objNull, ["isnotinside"]] call ace_common_fnc_canInteractWith}
 };
 
-[localize "STR_BTC_HAM_CON_INFO_SEARCH_BAR", btc_int_search_intel_time, _condition, _onFinish, {}, [_target, player, _radius]] call CBA_fnc_progressBar;
+[btc_int_search_intel_time, [_target, player, _radius], _onFinish, {}, localize "STR_BTC_HAM_CON_INFO_SEARCH_BAR", _condition, ["isNotInside"]] call ace_common_fnc_progressBar;


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Use ACE Progressbar for Interactions (@mrschick).

**When merged this pull request will:**
- Use the ACE ProgressBar instead of CBA ProgressBar on "Break Door" and "Search Intel" interactions.\
The ACE version is preferable since it allows CBA Keybinds to work while interacting, i.e: ACRE radio PTTs.

**Final test:**
- [x] local
- [x] server

**Screenshots**
