### PR TITLE
FIX: Backpacks with integrated Wirecutter can Break Doors

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/int/add_actions.sqf
@@ -237,7 +237,10 @@ if (btc_p_arsenal_Restrict isNotEqualTo 0) then {[btc_gear_object, btc_p_arsenal
 //Door
 _action = ["door_break", localize "STR_BTC_HAM_ACTION_DOOR_BREAK", "\A3\Ui_f\data\IGUI\Cfg\Actions\open_door_ca.paa", {
     [btc_door_fnc_break] call CBA_fnc_execNextFrame;
-}, {"ACE_wirecutter" in items player}] call ace_interact_menu_fnc_createAction;
+}, {
+    (((player call ace_common_fnc_uniqueItems) arrayIntersect ace_logistics_wirecutter_possibleWirecutters) isNotEqualTo []) || {getNumber ((configOf (backpackContainer player)) >> "ace_logistics_wirecutter_hasWirecutter") == 1} || 
+    {getNumber (configFile >> "CfgWeapons" >> (vest player) >> "ace_logistics_wirecutter_hasWirecutter") == 1}
+}] call ace_interact_menu_fnc_createAction;
 [player, 1, ["ACE_SelfActions", "ACE_Equipment"], _action] call ace_interact_menu_fnc_addActionToObject;
 
 //Flag


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Backpacks with integrated Wirecutter can Break Doors (@mrschick).

**When merged this pull request will:**
- Allow Break Door interaction when carrying a vest or backpack defined with it, as per the ACE [wirecutter framework](https://ace3.acemod.org/wiki/framework/wirecutter-framework).\
Reuses the following condition check used within ACE:\
https://github.com/acemod/ACE3/blob/3728bc4b8b30bb65b52c9b38762061cbf0933b4f/addons/logistics_wirecutter/script_component.hpp#L90-L93

**Final test:**
- [x] local
- [x] server

**Screenshots**
