### PR TITLE
FIX: Autosave after all players disconnect not  working always

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/server.sqf
@@ -79,7 +79,8 @@ addMissionEventHandler ["HandleDisconnect", {
 }] call CBA_fnc_addEventHandler;
 if (btc_p_auto_db) then {
     addMissionEventHandler ["HandleDisconnect", {
-        if ((allPlayers - entities "HeadlessClient_F") isEqualTo []) then {
+        params ["_player"];
+        if ((allPlayers - entities "HeadlessClient_F" - [_player]) isEqualTo []) then {
             [] call btc_db_fnc_save;
         };
     }];


### PR DESCRIPTION

<!-- Use English only. -->

- FIX: Autosave after all players disconnect not  working always (@Vdauphin).

**When merged this pull request will:**
- `allPlayers` is not always updated when player disconnect from the server
- When checking, we need to remove it from the player list if still present
- fix https://github.com/Vdauphin/HeartsAndMinds/issues/1651

**Final test:**
- [x] local
- [x] server

**Screenshots**
