### PR TITLE
Add: Setting to toggle chemical side mission and chemical weapon cache probability

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -84,7 +84,6 @@ btc_p_civ_max_veh = "btc_p_civ_max_veh" call BIS_fnc_getParamValue;
 
 //<< Gameplay options >>
 btc_p_sea = ("btc_p_sea" call BIS_fnc_getParamValue) isEqualTo 1;
-btc_p_chem = ("btc_p_chem" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_chem_sides = ("btc_p_chem_sides" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_chem_cache_probability = ("btc_p_chem_cache_probability" call BIS_fnc_getParamValue)/100;
 btc_p_spect = ("btc_p_spect" call BIS_fnc_getParamValue) isEqualTo 1;
@@ -233,7 +232,7 @@ if (isServer) then {
     btc_side_ID = 0;
     btc_side_list = ["supply", "mines", "vehicle", "get_city", "tower", "civtreatment", "checkpoint", "convoy", "rescue", "capture_officer", "hostage", "hack", "kill", "EMP", "removeRubbish", "massacre"]; // On ground (Side "convoy" and "capture_officer" are not design for map with different islands. Start and end city can be on different islands.)
     if (btc_p_sea) then {btc_side_list append ["civtreatment_boat", "underwater_generator"]}; // On sea
-    if (btc_p_chem && btc_p_chem_sides) then {btc_side_list append ["chemicalLeak", "pandemic"]};
+    if (btc_p_chem_sides) then {btc_side_list append ["chemicalLeak", "pandemic"]};
     btc_side_list_use = [];
     btc_type_tower = ["Land_Communication_F", "Land_TTowerBig_1_F", "Land_TTowerBig_2_F"];
     btc_type_barrel = ["Land_GarbageBarrel_01_F", "Land_BarrelSand_grey_F", "MetalBarrel_burning_F", "Land_BarrelWater_F", "Land_MetalBarrel_F", "Land_MetalBarrel_empty_F"];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -85,6 +85,8 @@ btc_p_civ_max_veh = "btc_p_civ_max_veh" call BIS_fnc_getParamValue;
 //<< Gameplay options >>
 btc_p_sea = ("btc_p_sea" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_chem = ("btc_p_chem" call BIS_fnc_getParamValue) isEqualTo 1;
+btc_p_chem_sides = ("btc_p_chem_sides" call BIS_fnc_getParamValue) isEqualTo 1;
+btc_p_chem_cache_probability = ("btc_p_chem_cache_probability" call BIS_fnc_getParamValue)/100;
 btc_p_spect = ("btc_p_spect" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_side_mission_cycle = "btc_p_side_mission_cycle" call BIS_fnc_getParamValue;
 
@@ -231,7 +233,7 @@ if (isServer) then {
     btc_side_ID = 0;
     btc_side_list = ["supply", "mines", "vehicle", "get_city", "tower", "civtreatment", "checkpoint", "convoy", "rescue", "capture_officer", "hostage", "hack", "kill", "EMP", "removeRubbish", "massacre"]; // On ground (Side "convoy" and "capture_officer" are not design for map with different islands. Start and end city can be on different islands.)
     if (btc_p_sea) then {btc_side_list append ["civtreatment_boat", "underwater_generator"]}; // On sea
-    if (btc_p_chem) then {btc_side_list append ["chemicalLeak", "pandemic"]};
+    if (btc_p_chem && btc_p_chem_sides) then {btc_side_list append ["chemicalLeak", "pandemic"]};
     btc_side_list_use = [];
     btc_type_tower = ["Land_Communication_F", "Land_TTowerBig_1_F", "Land_TTowerBig_2_F"];
     btc_type_barrel = ["Land_GarbageBarrel_01_F", "Land_BarrelSand_grey_F", "MetalBarrel_burning_F", "Land_BarrelWater_F", "Land_MetalBarrel_F", "Land_MetalBarrel_empty_F"];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -407,7 +407,7 @@ class Params {
         texts[] = {$STR_DISABLED,$STR_ENABLED};
         default = 1;
     };
-    class btc_p_chem_cache_probability { // Advanced Chemical warfare setting to change probability of a chemical weapon cache
+    class btc_p_chem_cache_probability { // Chemical weapon cache probability:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_CACHE_PROBABILITY"]);
         values[]={0,10,20,30,40,50,60,70,80,90,100};
         texts[]={"0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -401,11 +401,23 @@ class Params {
         texts[] = {$STR_DISABLED,$STR_ENABLED};
         default = 1;
     };
-    class btc_p_chem { // Chemical warfare
+    class btc_p_chem { // Chemical warfare ON / OFF
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_GAMEPLAY_CHEM"]);
         values[] = {0,1};
         texts[] = {$STR_DISABLED,$STR_ENABLED};
         default = 1;
+    };
+    class btc_p_chem_sides { // Advanced Chemical warfare setting to activate / deactivate chemical side missions
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_SIDES"]);
+        values[] = {0,1};
+        texts[] = {$STR_DISABLED,$STR_ENABLED};
+        default = 1;
+    };
+    class btc_p_chem_cache_probability { // Advanced Chemical warfare setting to change probability of a chemical weapon cache
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_CACHE_PROBABILITY"]);
+        values[]={10,20,30,40,50,60,70,80,90,100};
+        texts[]={"10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"};
+        default = 50;
     };
     class btc_p_spect { // Spectrum devices
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_GAMEPLAY_SPECT"]);

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -415,8 +415,8 @@ class Params {
     };
     class btc_p_chem_cache_probability { // Advanced Chemical warfare setting to change probability of a chemical weapon cache
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_CACHE_PROBABILITY"]);
-        values[]={10,20,30,40,50,60,70,80,90,100};
-        texts[]={"10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"};
+        values[]={0,10,20,30,40,50,60,70,80,90,100};
+        texts[]={"0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"};
         default = 50;
     };
     class btc_p_spect { // Spectrum devices

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -401,7 +401,7 @@ class Params {
         texts[] = {$STR_DISABLED,$STR_ENABLED};
         default = 1;
     };
-    class btc_p_chem_sides { // Advanced Chemical warfare setting to activate / deactivate chemical side missions
+    class btc_p_chem_sides { // Toggle chemical side missions:
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_SIDES"]);
         values[] = {0,1};
         texts[] = {$STR_DISABLED,$STR_ENABLED};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -401,12 +401,6 @@ class Params {
         texts[] = {$STR_DISABLED,$STR_ENABLED};
         default = 1;
     };
-    class btc_p_chem { // Chemical warfare ON / OFF
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_GAMEPLAY_CHEM"]);
-        values[] = {0,1};
-        texts[] = {$STR_DISABLED,$STR_ENABLED};
-        default = 1;
-    };
     class btc_p_chem_sides { // Advanced Chemical warfare setting to activate / deactivate chemical side missions
         title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_SIDES"]);
         values[] = {0,1};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/create.sqf
@@ -28,7 +28,7 @@ Author:
 
 params [
     ["_cache_pos", btc_cache_pos, [[]]],
-    ["_p_chem", (btc_p_chem_cache_probability > 0), [true]],
+    ["_p_chem", btc_p_chem_cache_probability > 0, [true]],
     ["_probabilityChemical", btc_p_chem_cache_probability, [0]]
 ];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/create.sqf
@@ -8,7 +8,7 @@ Description:
 Parameters:
     _cache_pos - Position of the cache. [Array]
     _p_chem - Allow chemical cache. [Boolean]
-    _probabilityNotChemical - Probability to not create a chemical cache. [Number]
+    _probabilityChemical - Probability to create a chemical cache. [Number]
 
 Returns:
 
@@ -28,13 +28,13 @@ Author:
 
 params [
     ["_cache_pos", btc_cache_pos, [[]]],
-    ["_p_chem", btc_p_chem, [true]],
-    ["_probabilityNotChemical", 0.5, [0]]
+    ["_p_chem", btc_p_chem && (btc_p_chem_cache_probability > 0), [true]],
+    ["_probabilityChemical", btc_p_chem_cache_probability, [0]]
 ];
 
 private _isChem = false;
 if (_p_chem) then {
-    _isChem = random 1 > _probabilityNotChemical;
+    _isChem = random 1 < _probabilityChemical;
 };
 private _cacheType = selectRandom (btc_cache_type select 0);
 btc_cache_obj = _cacheType createVehicle _cache_pos;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/create.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/create.sqf
@@ -28,7 +28,7 @@ Author:
 
 params [
     ["_cache_pos", btc_cache_pos, [[]]],
-    ["_p_chem", btc_p_chem && (btc_p_chem_cache_probability > 0), [true]],
+    ["_p_chem", (btc_p_chem_cache_probability > 0), [true]],
     ["_probabilityChemical", btc_p_chem_cache_probability, [0]]
 ];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/checkLoop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/checkLoop.sqf
@@ -19,9 +19,7 @@ Author:
 
 ---------------------------------------------------------------------------- */
 
-private _isChem = (btc_p_chem_sides || (btc_p_chem_cache_probability > 0));
-
-if !(_isChem) exitWith {};
+if !(btc_p_chem_sides || (btc_p_chem_cache_probability > 0)) exitWith {};
 
 private _bodyParts = ["head","body","hand_l","hand_r","leg_l","leg_r"];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/checkLoop.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/checkLoop.sqf
@@ -19,7 +19,9 @@ Author:
 
 ---------------------------------------------------------------------------- */
 
-if !(btc_p_chem) exitWith {};
+private _isChem = (btc_p_chem_sides || (btc_p_chem_cache_probability > 0));
+
+if !(_isChem) exitWith {};
 
 private _bodyParts = ["head","body","hand_l","hand_r","leg_l","leg_r"];
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/handleShower.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/handleShower.sqf
@@ -20,7 +20,9 @@ Author:
 
 ---------------------------------------------------------------------------- */
 
-if !(btc_p_chem) exitWith {};
+private _isChem = (btc_p_chem_sides || (btc_p_chem_cache_probability > 0));
+
+if !(_isChem) exitWith {};
 
 params [
     ["_minDistance", 5, [2]]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/handleShower.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/chem/handleShower.sqf
@@ -20,9 +20,7 @@ Author:
 
 ---------------------------------------------------------------------------- */
 
-private _isChem = (btc_p_chem_sides || (btc_p_chem_cache_probability > 0));
-
-if !(_isChem) exitWith {};
+if !(btc_p_chem_sides || (btc_p_chem_cache_probability > 0)) exitWith {};
 
 params [
     ["_minDistance", 5, [2]]

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/create_patrol.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/create_patrol.sqf
@@ -26,8 +26,7 @@ Author:
 params [
     ["_group", grpNull, [grpNull]],
     ["_active_city", objNull, [objNull]],
-    ["_area", btc_patrol_area, [0]],
-    ["_p_chem", btc_p_chem, [false]]
+    ["_area", btc_patrol_area, [0]]
 ];
 
 if (isNil "btc_civilian_id") then {btc_civilian_id = -1;};

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -102,7 +102,7 @@ btc_cache_pos = _cache_pos;
 btc_cache_n = _cache_n;
 btc_cache_info = _cache_info;
 
-[_cache_pos, (btc_p_chem_cache_probability > 0), [1, 0] select _isChem] call btc_cache_fnc_create;
+[_cache_pos, btc_p_chem_cache_probability > 0, [1, 0] select _isChem] call btc_cache_fnc_create;
 btc_cache_obj setVariable ["btc_cache_unitsSpawned", _cache_unitsSpawned];
 
 btc_cache_markers = [];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -102,7 +102,7 @@ btc_cache_pos = _cache_pos;
 btc_cache_n = _cache_n;
 btc_cache_info = _cache_info;
 
-[_cache_pos, btc_p_chem, [1, 0] select _isChem] call btc_cache_fnc_create;
+[_cache_pos, btc_p_chem && (btc_p_chem_cache_probability > 0), [1, 0] select _isChem] call btc_cache_fnc_create;
 btc_cache_obj setVariable ["btc_cache_unitsSpawned", _cache_unitsSpawned];
 
 btc_cache_markers = [];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load.sqf
@@ -102,7 +102,7 @@ btc_cache_pos = _cache_pos;
 btc_cache_n = _cache_n;
 btc_cache_info = _cache_info;
 
-[_cache_pos, btc_p_chem && (btc_p_chem_cache_probability > 0), [1, 0] select _isChem] call btc_cache_fnc_create;
+[_cache_pos, (btc_p_chem_cache_probability > 0), [1, 0] select _isChem] call btc_cache_fnc_create;
 btc_cache_obj setVariable ["btc_cache_unitsSpawned", _cache_unitsSpawned];
 
 btc_cache_markers = [];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load_old.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load_old.sqf
@@ -100,7 +100,7 @@ btc_cache_pos = _cache_pos;
 btc_cache_n = _cache_n;
 btc_cache_info = _cache_info;
 
-[_cache_pos, (btc_p_chem_cache_probability > 0), [1, 0] select _isChem] call btc_cache_fnc_create;
+[_cache_pos, btc_p_chem_cache_probability > 0, [1, 0] select _isChem] call btc_cache_fnc_create;
 btc_cache_obj setVariable ["btc_cache_unitsSpawned", _cache_unitsSpawned];
 
 btc_cache_markers = [];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load_old.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load_old.sqf
@@ -100,7 +100,7 @@ btc_cache_pos = _cache_pos;
 btc_cache_n = _cache_n;
 btc_cache_info = _cache_info;
 
-[_cache_pos, btc_p_chem, [1, 0] select _isChem] call btc_cache_fnc_create;
+[_cache_pos, btc_p_chem && (btc_p_chem_cache_probability > 0), [1, 0] select _isChem] call btc_cache_fnc_create;
 btc_cache_obj setVariable ["btc_cache_unitsSpawned", _cache_unitsSpawned];
 
 btc_cache_markers = [];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load_old.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/db/load_old.sqf
@@ -100,7 +100,7 @@ btc_cache_pos = _cache_pos;
 btc_cache_n = _cache_n;
 btc_cache_info = _cache_info;
 
-[_cache_pos, btc_p_chem && (btc_p_chem_cache_probability > 0), [1, 0] select _isChem] call btc_cache_fnc_create;
+[_cache_pos, (btc_p_chem_cache_probability > 0), [1, 0] select _isChem] call btc_cache_fnc_create;
 btc_cache_obj setVariable ["btc_cache_unitsSpawned", _cache_unitsSpawned];
 
 btc_cache_markers = [];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/player.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/player.sqf
@@ -71,7 +71,9 @@ _player addEventHandler ["WeaponAssembled", {
     _this remoteExecCall ["btc_log_fnc_init", 2];
 }] call CBA_fnc_addEventHandler;
 
-if (btc_p_chem) then {
+private _isChem = (btc_p_chem_sides || (btc_p_chem_cache_probability > 0));
+
+if (_isChem) then {
     // Add biopsy
     [missionNamespace, "probingEnded", btc_chem_fnc_biopsy] call BIS_fnc_addScriptedEventHandler;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/player.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/player.sqf
@@ -71,9 +71,7 @@ _player addEventHandler ["WeaponAssembled", {
     _this remoteExecCall ["btc_log_fnc_init", 2];
 }] call CBA_fnc_addEventHandler;
 
-private _isChem = (btc_p_chem_sides || (btc_p_chem_cache_probability > 0));
-
-if (_isChem) then {
+if (btc_p_chem_sides || (btc_p_chem_cache_probability > 0)) then {
     // Add biopsy
     [missionNamespace, "probingEnded", btc_chem_fnc_biopsy] call BIS_fnc_addScriptedEventHandler;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/server.sqf
@@ -86,9 +86,7 @@ if (btc_p_auto_db) then {
     }];
 };
 
-private _isChem = (btc_p_chem_sides || (btc_p_chem_cache_probability > 0));
-
-if (_isChem) then {
+if (btc_p_chem_sides || (btc_p_chem_cache_probability > 0)) then {
     ["ace_cargoLoaded", btc_chem_fnc_propagate] call CBA_fnc_addEventHandler;
     ["AllVehicles", "GetIn", {[_this select 0, _this select 2] call btc_chem_fnc_propagate}] call CBA_fnc_addClassEventHandler;
     ["DeconShower_01_F", "init", {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/server.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/eh/server.sqf
@@ -85,7 +85,10 @@ if (btc_p_auto_db) then {
         };
     }];
 };
-if (btc_p_chem) then {
+
+private _isChem = (btc_p_chem_sides || (btc_p_chem_cache_probability > 0));
+
+if (_isChem) then {
     ["ace_cargoLoaded", btc_chem_fnc_propagate] call CBA_fnc_addEventHandler;
     ["AllVehicles", "GetIn", {[_this select 0, _this select 2] call btc_chem_fnc_propagate}] call CBA_fnc_addClassEventHandler;
     ["DeconShower_01_F", "init", {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -963,7 +963,7 @@
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_SIDES">
                 <Original>Chemical side missions:</Original>
-                <French>Missions secondaires chimiques:</French>
+                <French>Missions secondaires chimiques :</French>
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_CACHE_PROBABILITY">
                 <Original>Chemical weapon cache probability:</Original>

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -961,6 +961,14 @@
                 <French>Guerre chimique:</French>
                 <Czech>Chemická válka:</Czech>
             </Key>
+            <Key ID="STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_SIDES">
+                <Original>Chemical side missions:</Original>
+                <French>Missions secondaires chimiques:</French>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_CACHE_PROBABILITY">
+                <Original>Chemical weapon cache probability:</Original>
+                <French>Probabilité de cache d'armes chimique:</French>
+            </Key>
             <Key ID="STR_BTC_HAM_PARAM_GAMEPLAY_SPECT">
                 <Original>Spectrum devices:</Original>
                 <French>Appareils à spectre:</French>

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -967,7 +967,7 @@
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_GAMEPLAY_CHEM_CACHE_PROBABILITY">
                 <Original>Chemical weapon cache probability:</Original>
-                <French>Probabilité de cache d'armes chimique:</French>
+                <French>Probabilité de cache d'armes chimiques :</French>
             </Key>
             <Key ID="STR_BTC_HAM_PARAM_GAMEPLAY_SPECT">
                 <Original>Spectrum devices:</Original>


### PR DESCRIPTION
Hi,
I've made some changes in order to add some more advanced settings on the Chemical Warfare in H&M.
The idea is to enable chemical warfare and choose if the chemical side missions will spawn or not and also set a chance probability of having a chemical weapons cache or not.

- Add: Setting to toggle chemical side mission (@TomDraal).
- Add: Setting to change chemical weapon cache probability (@TomDraal).

**When merged this pull request will:**
- Allow the user to choose if he/she wants to have chemical side missions while chemical warfare is enabled
- Tweak the chance probability (%age) of having a chemical weapons cache

**Final test:**
- [X] local
- [X] server
