### PR TITLE
Custom Cache positions

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -197,7 +197,7 @@ if (isServer) then {
     btc_spect_emp = []; publicVariable "btc_spect_emp"; //Preserve reference
 
     //Cache
-	btc_cache_cityID = []; // List of city ID visible in debug mode for custom cache location
+    btc_cache_cityID = []; // List of city ID visible in debug mode for custom cache location
     btc_cache_type = [
         _allClassSorted select {
             _x isKindOf "ReammoBox_F" &&

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -197,6 +197,7 @@ if (isServer) then {
     btc_spect_emp = []; publicVariable "btc_spect_emp"; //Preserve reference
 
     //Cache
+	btc_cache_cityID = []; // List of city ID visible in debug mode for custom cache location
     btc_cache_type = [
         _allClassSorted select {
             _x isKindOf "ReammoBox_F" &&

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/find_pos.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/find_pos.sqf
@@ -31,6 +31,8 @@ if (_useful isEqualTo []) then {_useful = _city_all;};
 
 private _city = selectRandom _useful;
 
+if (!(btc_cache_cityID isEqualTo []) && count btc_cache_cityID > btc_cache_n) then {_city = btc_city_all get (btc_cache_cityID select btc_cache_n)};
+
 if (_city getVariable ["type", ""] in ["NameLocal", "Hill", "NameMarine"]) exitWith {
     [] call btc_cache_fnc_find_pos;
 };


### PR DESCRIPTION
This allows to set custom cache positions as for the hideouts. The custom locations are processed in the array order so the caches locations can follow the progression of the players.

- Add: allows to set custom cache positions as for the hideouts (@TomDraal).

**When merged this pull request will:**
- Add a new array "btc_cache_cityID" in mission.sqf where you can set the IDs of the cities you want the cache to spawn in 
- Change the "find_pos.sqf" to cycle through the new custom locations array by using the cache number ("btc_cache_n")

**Final test:**
- [ X ] local
- [ X ] server
