### PR TITLE
Custom cache locations

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -197,7 +197,7 @@ if (isServer) then {
     btc_spect_emp = []; publicVariable "btc_spect_emp"; //Preserve reference
 
     //Cache
-	btc_cache_cityID = []; // List of city ID visible in debug mode for custom cache location
+    btc_cache_cityID = []; // List of city ID visible in debug mode for custom cache location
     btc_cache_type = [
         _allClassSorted select {
             _x isKindOf "ReammoBox_F" &&

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -197,6 +197,7 @@ if (isServer) then {
     btc_spect_emp = []; publicVariable "btc_spect_emp"; //Preserve reference
 
     //Cache
+	btc_cache_cityID = []; // List of city ID visible in debug mode for custom cache location
     btc_cache_type = [
         _allClassSorted select {
             _x isKindOf "ReammoBox_F" &&

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/find_pos.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/find_pos.sqf
@@ -31,6 +31,8 @@ if (_useful isEqualTo []) then {_useful = _city_all;};
 
 private _city = selectRandom _useful;
 
+if (!(btc_cache_cityID isEqualTo []) && count btc_cache_cityID > btc_cache_n) then {_city = btc_city_all get (btc_cache_cityID select btc_cache_n)};
+
 if (_city getVariable ["type", ""] in ["NameLocal", "Hill", "NameMarine"]) exitWith {
     [] call btc_cache_fnc_find_pos;
 };

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/find_pos.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/cache/find_pos.sqf
@@ -27,11 +27,13 @@ params [
 
 private _useful = _city_all select {_x getVariable ["occupied", false] && {!(_x getVariable ["type", ""] in ["NameLocal", "Hill", "NameMarine"])}};
 
+if (!(btc_cache_cityID isEqualTo []) && count btc_cache_cityID > btc_cache_n) then {
+    _useful = _useful select {_x getVariable ["id",-1] == (btc_cache_cityID select btc_cache_n)};
+};
+
 if (_useful isEqualTo []) then {_useful = _city_all;};
 
 private _city = selectRandom _useful;
-
-if (!(btc_cache_cityID isEqualTo []) && count btc_cache_cityID > btc_cache_n) then {_city = btc_city_all get (btc_cache_cityID select btc_cache_n)};
 
 if (_city getVariable ["type", ""] in ["NameLocal", "Hill", "NameMarine"]) exitWith {
     [] call btc_cache_fnc_find_pos;


### PR DESCRIPTION
- Add: this feature allows to specify a list of City IDs to set where the caches will spawn in a specific order to follow the map progression. (@TomDraal).

**When merged this pull request will:**
- Add a new array called "btc_cache_cityID" to store the IDs of the cities we want a cache to spawn in "mission.sqf"
- Change how the next cache location is selected by using the new array if not empty in "find_pos.sqf"

**Final test:**
- [ X ] local
- [ X ] server