### PR TITLE
FIX: Wreck Fire killing Pilot in Rescue Mission

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/side/rescue.sqf
@@ -49,7 +49,7 @@ private _heli_type = typeOf selectRandom ((btc_vehicles + btc_veh_respawnable) s
 private _heli = createVehicle [_heli_type, _pos, [], 0, "NONE"];
 _heli setVariable ["btc_dont_delete", true];
 _heli setVariable ["ace_cookoff_enableAmmoCookoff", false, true];
-_heli setDamage 1;
+_heli setDamage [1, false];
 _heli enableSimulation false;
 _heli setPos [getPosASL _heli select 0, getPosASL _heli select 1, 0 - 1.5];
 private _pitch = if (random 1 > 0.5) then {


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Wreck Fire killing Pilot in Rescue Mission (@mrschick)

**When merged this pull request will:**
- title
Since https://github.com/acemod/ACE3/pull/9962 wrecks are a source of fire, this was causing rescue missions to fail immediately due to the pilot being burned (since he is spawned next to the wreck).
Fixed by explicitly disabling destruction effects, which prevents ACE from adding a fire source to the wreck.

**Final test:**
- [x] local
- [x] server
