### PR TITLE
FIX: Boat Patrols Spawning in Ponds

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/create_patrol.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/civ/create_patrol.sqf
@@ -50,7 +50,7 @@ _roads = _roads select {isOnRoad _x};
 if (_roads isEqualTo []) then {
     _safe_pos = [_pos, 0, 500, 13, [0,1] select btc_p_sea, 60 * (pi / 180), 0] call BIS_fnc_findSafePos;
     _safe_pos = [_safe_pos select 0, _safe_pos select 1, 0];
-    _pos_isWater = surfaceIsWater _safe_pos;
+    _pos_isWater = (surfaceIsWater _safe_pos) && {getTerrainHeightASL _safe_pos < -2};
     if (_pos_isWater) then {
         _veh_type = selectRandom btc_civ_type_boats;
     } else {

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_group.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_group.sqf
@@ -50,7 +50,7 @@ if (_wp isEqualTo "HOUSE") then { // Find building
 };
 
 _group_structure params ["_numberOfGroup", "_structure"];
-private _pos_iswater = surfaceIsWater _pos;
+private _pos_iswater = (surfaceIsWater _pos) && {getTerrainHeightASL _pos < -1};
 private _hashMapGroup = createHashMap;
 _hashMapGroup set ["_pos", _pos];
 if (

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_patrol.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/mil/create_patrol.sqf
@@ -62,7 +62,7 @@ if (_start_city getVariable ["hasbeach", false]) then {
 } else {
     _pos = getPos _start_city;
 };
-private _pos_isWater = surfaceIsWater _pos;
+private _pos_isWater = (surfaceIsWater _pos) && {getTerrainHeightASL _pos < -2};
 if (_pos_isWater) then {
     _pos = [_pos select 0, _pos select 1, 0];
     _random = 2;


### PR DESCRIPTION
<!-- Use English only. -->

- FIX: Boat Patrols Spawning in Ponds (@mrschick)

**When merged this pull request will:**
- Prevent boats from spawning in shallow water of less than 2m depth. Would happen frequently on the Vietnam map I'm currently using, resulting in Vietcong patrol boats spawning in rice fields that are cut off from the surrounding rivers.

**Final test:**
- [x] local
- [x] server
