### PR TITLE
Add: Allow Saving on Per-Player Base

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/mission.sqf
@@ -18,7 +18,7 @@ btc_p_db_autoRestartHour = [
     "btc_p_db_autoRestartHour2" call BIS_fnc_getParamValue
 ];
 btc_p_db_autoRestartType = "btc_p_db_autoRestartType" call BIS_fnc_getParamValue;
-btc_p_slot_isShare = "btc_p_slot_isShare" call BIS_fnc_getParamValue isEqualTo 1;
+btc_p_slot_saveMode = "btc_p_slot_saveMode" call BIS_fnc_getParamValue;
 btc_p_change_time = ("btc_p_change_time" call BIS_fnc_getParamValue) isEqualTo 1;
 btc_p_change_weather = ("btc_p_change_weather" call BIS_fnc_getParamValue) isEqualTo 1;
 

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -137,10 +137,10 @@ class Params {
         texts[]={$STR_DISABLED,$STR_ENABLED};
         default = 1;
     };
-    class btc_p_slot_isShare { // Each slot is share between players
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SLOT_ISSHARE"]);
-        values[]={0,1};
-        texts[]={$STR_DISABLED, $STR_ENABLED};
+    class btc_p_slot_saveMode { // How to save/serialize a slot
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SLOT_SAVEMODE"]);
+        values[]={0,1,2};
+        texts[]={$STR_BTC_HAM_PARAM_SLOT_PERPLAYERANDSLOT, $STR_BTC_HAM_PARAM_SLOT_PERSLOT, $STR_BTC_HAM_PARAM_SLOT_PERPLAYER}; // texts[]={"Per player and slot", "Per slot", "Per player"}
         default = 1;
     };
     class btc_p_type_title { // << Faction options >>

--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/slot/createKey.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/slot/createKey.sqf
@@ -24,9 +24,18 @@ params [
     ["_player", objNull, [objNull]]
 ];
 
-private _key = position _player;
-if !(btc_p_slot_isShare) then {
-    _key pushBack getPlayerUID _player;
+private _key = switch (btc_p_slot_saveMode) do {
+    case 0: { // per player and slot combination
+        private _key = position _player;
+        _key pushBack getPlayerUID _player;
+        _key
+    };
+    case 1: { // per slot
+        position _player
+    };
+    case 2: { // per player
+        [getPlayerUID _player]
+    };
 };
 
 _player setVariable ["btc_slot_key", _key];

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -871,9 +871,21 @@
                 <French>Arsenal ACE disponible après avoir était tué:</French>
                 <Czech>ACE Arsenal dostupný při respawnu po zabití:</Czech>
             </Key>
-            <Key ID="STR_BTC_HAM_PARAM_SLOT_ISSHARE">
-                <Original>Each slot is share between players</Original>
-                <French>Les slots sont partagés entre tous les joueurs</French>
+            <Key ID="STR_BTC_HAM_PARAM_SLOT_SAVEMODE">
+                <Original>Save unit state:</Original>
+                <German>Speicher Einheiten Zustand:</German>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_SLOT_PERPLAYERANDSLOT">
+                <Original>Per player and slot combination</Original>
+                <German>Je Spieler und Slot Kombination</German>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_SLOT_PERSLOT">
+                <Original>Per slot (Shared between players)</Original>
+                <German>Je Slot (Geteilt zwischen Spielern)</German>
+            </Key>
+            <Key ID="STR_BTC_HAM_PARAM_SLOT_PERPLAYER">
+                <Original>Per player (slot independent)</Original>
+                <German>Je Spieler (Slot unabhängig)</German>
             </Key>
         </Container>
         <Container name="Parameters: AI Skill">


### PR DESCRIPTION
- Add: : Allow Saving on Per-Player Base (@Zakant)

**When merged this pull request will:**
- Rename the `slot_isShared` setting to `slot_saveMode`
- Allow saving a units state on a "per-player" base. This makes a player get the same game state regardless of the slot picked. The old options "not shared" and "shared" are still available and renamed to "Per slot player combination" and "Per slot". The defaults are keept intact so old missions should just "work".
- I'm not super happy with the naming of the settings (especially the localized strings)....

**Final test:**
- [x] local
- [x] server
