### PR TITLE
Fix: Typo in Stringtable Key

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/def/param.hpp
@@ -186,37 +186,37 @@ class Params {
         default = 0;
     };
     class btc_p_density_of_occupiedCity { // Density of city occupied:
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_ISOCCUPIED_DENSITY"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPAWN_ISOCCUPIED_DENSITY"]);
         values[]={0,10,20,30,40,45,50,60,70,80,90,100};
         texts[]={"0%","10%","20%","30%","40%","45%","50%","60%","70%","80%","90%","100%"};
         default = 45;
     };
     class btc_p_mil_group_ratio { // Enemy density:
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_ENEMY_DENSITY"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPAWN_ENEMY_DENSITY"]);
         values[]={0,10,20,30,40,50,60,70,80,90,100};
         texts[]={"0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"};
         default = 40;
     };
     class btc_p_wp_houseDensity { // Density of military in house: (Can't be above 100%)
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_MIL_INHOUSE_DENSITY"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPAWN_MIL_INHOUSE_DENSITY"]);
         values[]={0,10,20,30,40,50,60,70,80,90,100};
         texts[]={"0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"};
         default = 50;
     };
     class btc_p_mil_static_group_ratio { // Enemy static density:
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_ENEMY_STATIC_DENSITY"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPAWN_ENEMY_STATIC_DENSITY"]);
         values[]={0,10,20,30,40,50,60,70,80,90,100};
         texts[]={"0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"};
         default = 30;
     };
     class btc_p_civ_group_ratio { // Civilian density:
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_CIVILIAN_DENSITY"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPAWN_CIVILIAN_DENSITY"]);
         values[]={0,10,20,30,40,50,60,70,80,90,100};
         texts[]={"0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"};
         default = 50;
     };
     class btc_p_animals_group_ratio { // Animal density:
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_ANIMALS_DENSITY"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPAWN_ANIMALS_DENSITY"]);
         values[]={0,10,20,30,40,50,60,70,80,90,100};
         texts[]={"0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"};
         default = 100;
@@ -234,13 +234,13 @@ class Params {
         default = 0;
     };
     class btc_p_patrol_max { // Maximum number of military patrol:
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_PATROL_MAX"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPAWN_PATROL_MAX"]);
         values[]={0,1,2,3,4,5,6,7,8,9,10};
         texts[]={"1","2","3","4","5","6","7","8","9","10"};
         default = 9;
     };
     class btc_p_civ_max_veh { // Maximum number of civilian patrol:
-        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPWAN_CIV_MAX_VEH"]);
+        title = __EVAL(format ["      %1", localize "STR_BTC_HAM_PARAM_SPAWN_CIV_MAX_VEH"]);
         values[]={0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
         texts[]={"1","2","3","4","5","6","7","8","9","10","11","12","13","14","15"};
         default = 10;

--- a/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/stringtable.xml
@@ -473,14 +473,14 @@
                 <French>&lt;&lt; Options de spawn &gt;&gt;</French>
                 <Czech>&lt;&lt; Spawn možnosti &gt;&gt;</Czech>
             </Key>
-            <Key ID="STR_BTC_HAM_PARAM_SPWAN_ISOCCUPIED_DENSITY">
+            <Key ID="STR_BTC_HAM_PARAM_SPAWN_ISOCCUPIED_DENSITY">
                 <Original>Density of occupied city:</Original>
                 <German>Density of occupied city:</German>
                 <Chinesesimp>被敌军占领城市的密度:</Chinesesimp>
                 <French>Densité de villes occupées:</French>
                 <Czech>Hustota obsazeného města:</Czech>
             </Key>
-            <Key ID="STR_BTC_HAM_PARAM_SPWAN_ENEMY_DENSITY">
+            <Key ID="STR_BTC_HAM_PARAM_SPAWN_ENEMY_DENSITY">
                 <Original>Enemy density:</Original>
                 <German>Feinddichte:</German>
                 <Chinesesimp>敌军密度:</Chinesesimp>
@@ -488,13 +488,13 @@
                 <French>Densité des énnemies:</French>
                 <Czech>Hustota nepřátel:</Czech>
             </Key>
-            <Key ID="STR_BTC_HAM_PARAM_SPWAN_ENEMY_STATIC_DENSITY">
+            <Key ID="STR_BTC_HAM_PARAM_SPAWN_ENEMY_STATIC_DENSITY">
                 <Original>Enemy static density:</Original>
                 <Chinesesimp>敌军固定式武器密度:</Chinesesimp>
                 <French>Densité des armes statiques ennemies:</French>
                 <Czech>Statická hustota nepřítele:</Czech>
             </Key>
-            <Key ID="STR_BTC_HAM_PARAM_SPWAN_CIVILIAN_DENSITY">
+            <Key ID="STR_BTC_HAM_PARAM_SPAWN_CIVILIAN_DENSITY">
                 <Original>Civilian density:</Original>
                 <German>Zivilistendichte:</German>
                 <Chinesesimp>平民密度:</Chinesesimp>
@@ -502,13 +502,13 @@
                 <French>Densité des civil:</French>
                 <Czech>Civilní hustota:</Czech>
             </Key>
-            <Key ID="STR_BTC_HAM_PARAM_SPWAN_ANIMALS_DENSITY">
+            <Key ID="STR_BTC_HAM_PARAM_SPAWN_ANIMALS_DENSITY">
                 <Original>Animal density:</Original>
                 <Chinesesimp>动物密度:</Chinesesimp>
                 <French>Densité des animaux:</French>
                 <Czech>Hustota zvířat:</Czech>
             </Key>
-            <Key ID="STR_BTC_HAM_PARAM_SPWAN_MIL_INHOUSE_DENSITY">
+            <Key ID="STR_BTC_HAM_PARAM_SPAWN_MIL_INHOUSE_DENSITY">
                 <Original>Density of military in house:</Original>
                 <German>Feinddichte in Gebäuden:</German>
                 <Chinesesimp>建筑物中的敌军密度:</Chinesesimp>
@@ -532,7 +532,7 @@
                 <French>Ajouter des véhicules armés dans les missions secondaires / les caches d'armes:</French>
                 <Czech>Přidejte ozbrojená vozidla do vedlejší mise/mezipaměti:</Czech>
             </Key>
-            <Key ID="STR_BTC_HAM_PARAM_SPWAN_PATROL_MAX">
+            <Key ID="STR_BTC_HAM_PARAM_SPAWN_PATROL_MAX">
                 <Original>Maximum number of military patrol:</Original>
                 <German>Maximale Anzahl feindl. Patrouillen:</German>
                 <Chinesesimp>敌方巡逻队数量上限:</Chinesesimp>
@@ -540,7 +540,7 @@
                 <French>Nombre maximum de patrouilles militaires:</French>
                 <Czech>Maximální počet vojenských hlídek:</Czech>
             </Key>
-            <Key ID="STR_BTC_HAM_PARAM_SPWAN_CIV_MAX_VEH">
+            <Key ID="STR_BTC_HAM_PARAM_SPAWN_CIV_MAX_VEH">
                 <Original>Maximum number of civilian patrol:</Original>
                 <German>Maximale Anzahl an ziviler Fahrzeuge:</German>
                 <Chinesesimp>民用车辆数量上限:</Chinesesimp>


### PR DESCRIPTION
- Fix: : Typo in Stringtable Key (@Zakant)

**When merged this pull request will:**
- Fix a typo in the stringtable key `STR_BTC_HAM_PARAM_SPWAN` -> `STR_BTC_HAM_PARAM_SPAWN`

**Final test:**
- [x] local
- [x] server
